### PR TITLE
virtual server updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ branches:
 before_install:
   - cd ${TRAVIS_BUILD_DIR} && { curl -O http://visp-doc.inria.fr/download/dataset/ViSP-images-3.0.0.zip ; cd -; }
   - unzip ${TRAVIS_BUILD_DIR}/ViSP-images-3.0.0.zip -d ${TRAVIS_BUILD_DIR}
+  - git clone https://github.com/lagadic/ustk-dataset.git /tmp/ustk-dataset
+  - export USTK_DATASET_PATH=/tmp/ustk-dataset
   # Get libs for OSX
   - "if [ $TRAVIS_OS_NAME = 'osx' ]; then brew update; fi"
   #- "if [ $TRAVIS_OS_NAME = 'osx' ]; then brew tap homebrew/science; fi"

--- a/apps/ustk/virtual-server/usVirtualServer.cpp
+++ b/apps/ustk/virtual-server/usVirtualServer.cpp
@@ -597,13 +597,43 @@ void usVirtualServer::sendingLoopSequenceMHD()
       } else if (m_imageType == us::PRESCAN_2D) {
         if (m_usePause) {
           if (!m_pauseOn) {
-            uint64_t localTimestamp;
-            m_MHDSequenceReader.acquire(m_preScanImage2d, localTimestamp);
-            invertRowsColsOnPreScan(); // to fit with ultrasonix grabbers (pre-scan image is inverted in porta SDK)
-            imageHeader.timeStamp = localTimestamp + m_pauseDurationOffset;
-            if (!m_MHDSequenceReader.end())
-              m_nextImageTimestamp = m_MHDSequenceReader.getNextTimeStamp() + m_pauseDurationOffset;
-            imageHeader.imageType = 0;
+            if (m_useRewind &&
+                (imageHeader.frameCount - m_pauseIndexOffset) >=
+                    m_MHDSequenceReader.getTotalImageNumber()) { // TODO : pause + rewind
+              // counting the number of total sequence sent
+              unsigned int currentNumberOfWholeSequenceSent =
+                  ((imageHeader.frameCount - m_pauseIndexOffset - m_MHDSequenceReader.getTotalImageNumber()) /
+                   (m_MHDSequenceReader.getTotalImageNumber() - 1)) +
+                  1;
+
+              if (currentNumberOfWholeSequenceSent % 2 == 0) {
+                int imageIndex =
+                    (imageHeader.frameCount - m_pauseIndexOffset - m_MHDSequenceReader.getTotalImageNumber()) %
+                        (m_MHDSequenceReader.getTotalImageNumber() - 1) +
+                    1;
+                /*uint64_t localTimestamp;
+                m_MHDSequenceReader.getImage(imageIndex, m_preScanImage2d, localTimestamp);
+                invertRowsColsOnPreScan(); // to fit with ultrasonix grabbers (pre-scan image is inverted in porta SDK)
+                imageHeader.timeStamp = localTimestamp + m_pauseDurationOffset;
+                if (imageIndex != m_MHDSequenceReader.getTotalImageNumber())
+                  m_nextImageTimestamp = m_MHDSequenceReader.getNextTimeStamp() + m_pauseDurationOffset;
+                else { // next timestamp is the previous image
+                }
+                imageHeader.imageType = 0;*/
+              } else {
+                int imageIndex =
+                    (imageHeader.frameCount - m_pauseIndexOffset - m_MHDSequenceReader.getTotalImageNumber()) %
+                    (m_MHDSequenceReader.getTotalImageNumber() - 1);
+              }
+            } else {
+              uint64_t localTimestamp;
+              m_MHDSequenceReader.acquire(m_preScanImage2d, localTimestamp);
+              invertRowsColsOnPreScan(); // to fit with ultrasonix grabbers (pre-scan image is inverted in porta SDK)
+              imageHeader.timeStamp = localTimestamp + m_pauseDurationOffset;
+              if (!m_MHDSequenceReader.end())
+                m_nextImageTimestamp = m_MHDSequenceReader.getNextTimeStamp() + m_pauseDurationOffset;
+              imageHeader.imageType = 0;
+            }
           } else { // pause activated, we continue sending the same image, and increasing timestamps
             uint64_t deltaT = m_nextImageTimestamp - imageHeader.timeStamp;
             m_nextImageTimestamp += deltaT;
@@ -614,6 +644,95 @@ void usVirtualServer::sendingLoopSequenceMHD()
 
           if (imageHeader.frameCount == m_pauseImageNumber)
             m_pauseOn = true;
+        } else if (m_useRewind) {
+          // counting the number of total sequence sent
+          unsigned int currentNumberOfWholeSequenceSent = 0;
+          if (imageHeader.frameCount >= m_MHDSequenceReader.getTotalImageNumber()) {
+            currentNumberOfWholeSequenceSent = ((imageHeader.frameCount - m_MHDSequenceReader.getTotalImageNumber()) /
+                                                (m_MHDSequenceReader.getTotalImageNumber() - 1)) +
+                                               1;
+          }
+          if (currentNumberOfWholeSequenceSent == 0) { // sending first sequence
+            int imageIndex = (imageHeader.frameCount % (m_MHDSequenceReader.getTotalImageNumber()));
+
+            uint64_t localTimestamp;
+            m_MHDSequenceReader.acquire(m_preScanImage2d, localTimestamp);
+            invertRowsColsOnPreScan(); // to fit with ultrasonix grabbers (pre-scan image is inverted in porta SDK)
+            imageHeader.timeStamp = localTimestamp;
+            if (imageIndex != m_MHDSequenceReader.getTotalImageNumber() - 1) {
+              m_nextImageTimestamp = m_MHDSequenceReader.getNextTimeStamp();
+            } else { // next timestamp is the previous image, so we compute the abs diff between 2 timpestamps
+              // first we get the timestamp of the previous image
+              usImagePreScan2D<unsigned char> tmpImg;
+              uint64_t tmpTimpstamp;
+              m_MHDSequenceReader.getImage(imageIndex - 1, tmpImg, tmpTimpstamp);
+              // then we compute the delta
+              m_nextImageTimestamp = (imageHeader.timeStamp - tmpTimpstamp) + imageHeader.timeStamp;
+            }
+            imageHeader.imageType = 0;
+
+          } else if (currentNumberOfWholeSequenceSent % 2 == 0) {
+            int imageIndex = (imageHeader.frameCount - m_MHDSequenceReader.getTotalImageNumber()) %
+                                 (m_MHDSequenceReader.getTotalImageNumber() - 1) +
+                             1;
+
+            // current real timestamp
+            uint64_t localTimestamp;
+            m_MHDSequenceReader.getImage(imageIndex, m_preScanImage2d, localTimestamp);
+            invertRowsColsOnPreScan(); // to fit with ultrasonix grabbers (pre-scan image is inverted in porta SDK)
+            // offset (increment because of rewind)
+            uint64_t previousTimestamp;
+            usImagePreScan2D<unsigned char> tmpImg;
+            m_MHDSequenceReader.getImage(imageIndex - 1, tmpImg, previousTimestamp);
+            uint64_t deltaTimestamp = localTimestamp - previousTimestamp;
+            imageHeader.timeStamp += deltaTimestamp;
+
+            // next timestamp (for waiting process)
+            uint64_t nextTimestamp;
+            uint64_t deltaTimestampNext;
+            if (imageIndex != m_MHDSequenceReader.getTotalImageNumber() - 1) {
+              usImagePreScan2D<unsigned char> tmpImg;
+              m_MHDSequenceReader.getImage(imageIndex + 1, tmpImg, nextTimestamp);
+              deltaTimestampNext = nextTimestamp - localTimestamp;
+            } else {
+              usImagePreScan2D<unsigned char> tmpImg;
+              m_MHDSequenceReader.getImage(imageIndex - 1, tmpImg, nextTimestamp);
+              deltaTimestampNext = localTimestamp - nextTimestamp;
+            }
+            m_nextImageTimestamp += deltaTimestampNext;
+
+            imageHeader.imageType = 0;
+          } else {
+            int imageIndex = m_MHDSequenceReader.getTotalImageNumber() - 2 -
+                             ((imageHeader.frameCount - m_MHDSequenceReader.getTotalImageNumber()) %
+                              (m_MHDSequenceReader.getTotalImageNumber() - 1));
+
+            // current real timestamp
+            uint64_t localTimestamp;
+            m_MHDSequenceReader.getImage(imageIndex, m_preScanImage2d, localTimestamp);
+            invertRowsColsOnPreScan(); // to fit with ultrasonix grabbers (pre-scan image is inverted in porta SDK)
+            // offset (increment because of rewind)
+            uint64_t previousTimestamp;
+            usImagePreScan2D<unsigned char> tmpImg;
+            m_MHDSequenceReader.getImage(imageIndex + 1, tmpImg, previousTimestamp);
+            uint64_t deltaTimestamp = previousTimestamp - localTimestamp;
+            imageHeader.timeStamp += deltaTimestamp;
+
+            // next timestamp (for waiting process)
+            uint64_t nextTimestamp;
+            uint64_t deltaTimestampNext;
+            if (imageIndex != 0) {
+              usImagePreScan2D<unsigned char> tmpImg;
+              m_MHDSequenceReader.getImage(imageIndex - 1, tmpImg, nextTimestamp);
+              deltaTimestampNext = localTimestamp - nextTimestamp;
+            } else {
+              usImagePreScan2D<unsigned char> tmpImg;
+              m_MHDSequenceReader.getImage(imageIndex + 1, tmpImg, nextTimestamp);
+              deltaTimestampNext = nextTimestamp - localTimestamp;
+            }
+            m_nextImageTimestamp += deltaTimestampNext;
+            imageHeader.imageType = 0;
+          }
         } else {
           uint64_t localTimestamp;
           m_MHDSequenceReader.acquire(m_preScanImage2d, localTimestamp);
@@ -780,7 +899,7 @@ void usVirtualServer::sendingLoopSequenceMHD()
       out.writeRawData((char *)m_preScanImage2d.bitmap,
                        (int)m_preScanImage2d.getHeight() * m_preScanImage2d.getWidth());
 
-      endOfSequence = m_MHDSequenceReader.end();
+      endOfSequence = m_MHDSequenceReader.end() && !m_useRewind;
 
       connectionSoc->write(block);
       qApp->processEvents();
@@ -815,11 +934,10 @@ void usVirtualServer::sendingLoopSequenceMHD()
       out << m_postScanImage2d.getScanLinePitch();
       out << (int)m_postScanImage2d.getScanLineNumber();
       out << (int)(m_postScanImage2d.getDepth() * 1000.0); // int in mm
-      std::cout << "depth : " << m_postScanImage2d.getDepth() << std::endl;
-      out << (double).0; // degPerFrame
-      out << (int)0;     // framesPerVolume
-      out << (double).0; // motorRadius
-      out << (int)0;     // motorType
+      out << (double).0;                                   // degPerFrame
+      out << (int)0;                                       // framesPerVolume
+      out << (double).0;                                   // motorRadius
+      out << (int)0;                                       // motorType
       out.writeRawData((char *)m_postScanImage2d.bitmap,
                        (int)m_postScanImage2d.getHeight() * m_postScanImage2d.getWidth());
 

--- a/apps/ustk/virtual-server/virtualServer.cpp
+++ b/apps/ustk/virtual-server/virtualServer.cpp
@@ -41,7 +41,9 @@ int main(int argc, char **argv)
     if (std::string(argv[i]) == "--input")
       filename = std::string(argv[i + 1]);
     else if (std::string(argv[i]) == "--help") {
-      std::cout << "\nUsage: " << argv[0] << " [--input <mysequence.xml>] [--help]\n" << std::endl;
+      std::cout << "\nUsage: " << argv[0]
+                << " [--input <mysequence.mhd>] [--help] [--rewind] [--pause <imageToPauseOn]>\n"
+                << std::endl;
       return 0;
     }
   }

--- a/modules/ustk_core/CMakeLists.txt
+++ b/modules/ustk_core/CMakeLists.txt
@@ -42,6 +42,6 @@ vp_glob_module_sources()
 vp_module_include_directories(${opt_incs})
 vp_create_module(${opt_libs})
 
-vp_add_tests()
+vp_add_tests(DEPENDS_ON visp_ustk_io)
 
 vp_add_config_file("cmake/templates/usConfig.h.in")

--- a/modules/ustk_core/include/visp3/ustk_core/usPostScanToPreScan2DConverter.h
+++ b/modules/ustk_core/include/visp3/ustk_core/usPostScanToPreScan2DConverter.h
@@ -95,7 +95,8 @@ public:
 
   ~usPostScanToPreScan2DConverter();
 
-  void convert(const usImagePostScan2D<unsigned char> &imageToConvert, usImagePreScan2D<unsigned char> &imageConverted);
+  void convert(const usImagePostScan2D<unsigned char> &imageToConvert, usImagePreScan2D<unsigned char> &imageConverted,
+               int preScanSamples);
 
 protected:
   void init(const usImagePostScan2D<unsigned char> &inputSettings, const int BModeSampleNumber,

--- a/modules/ustk_core/src/scanConversion/usPostScanToPreScan2DConverter.cpp
+++ b/modules/ustk_core/src/scanConversion/usPostScanToPreScan2DConverter.cpp
@@ -33,7 +33,6 @@
 #include <visp3/ustk_core/usPostScanToPreScan2DConverter.h>
 
 //#include <visp/vpMath.h>
-
 /**
  * Default constructor.
  */
@@ -188,13 +187,13 @@ void usPostScanToPreScan2DConverter::init(const usTransducerSettings &transducer
 * Run the back-scan converter.
 * @param [in] imageToConvert Post-scan image to convert back.
 * @param [out] imageConverted Pre-scan image obtained after back conversion.
+* @param [in] preScanSamples Pre-scan samples number wanted in output.
 */
 void usPostScanToPreScan2DConverter::convert(const usImagePostScan2D<unsigned char> &imageToConvert,
-                                             usImagePreScan2D<unsigned char> &imageConverted)
+                                             usImagePreScan2D<unsigned char> &imageConverted, int preScanSamples)
 {
   if (!m_isInit) {
-    init(imageToConvert, (int)(imageToConvert.getDepth() / imageToConvert.getHeightResolution()),
-         imageToConvert.getScanLineNumber());
+    init(imageToConvert, preScanSamples, imageToConvert.getScanLineNumber());
   }
 
   imageConverted.setImagePreScanSettings(usImagePreScanSettings(m_initSettings, m_yResolution));

--- a/modules/ustk_core/src/scanConversion/usPreScanToPostScan2DConverter.cpp
+++ b/modules/ustk_core/src/scanConversion/usPreScanToPostScan2DConverter.cpp
@@ -225,6 +225,7 @@ void usPreScanToPostScan2DConverter::convert(const usImagePreScan2D<unsigned cha
   postScanImage.setTransducerConvexity(preScanImage.isTransducerConvex());
   postScanImage.setScanLinePitch(m_settings.getScanLinePitch());
   postScanImage.setTransducerRadius(m_settings.getTransducerRadius());
+  postScanImage.setDepth(m_settings.getDepth());
 }
 
 double usPreScanToPostScan2DConverter::interpolateLinear(const vpImage<unsigned char> &I, double x, double y)

--- a/modules/ustk_core/test/scanConversion/testUsScanConversion.cpp
+++ b/modules/ustk_core/test/scanConversion/testUsScanConversion.cpp
@@ -62,7 +62,7 @@ int main(int argc, const char **argv)
   std::cout << "-------------------------------------------------------" << std::endl;
   std::cout << "  testUsScanConversion2D.cpp" << std::endl << std::endl;
   std::cout << "  The test converts a pre-scan image to post-scan, and converts it back to pre-scan."
-               "  Then it checks if the 2 pre-scan images are equal."
+               "  Then it checks if the difference between the 2 images, using sum of square differences."
             << std::endl;
   std::cout << "-------------------------------------------------------" << std::endl;
   std::cout << std::endl;
@@ -82,18 +82,20 @@ int main(int argc, const char **argv)
   usPostScanToPreScan2DConverter backScanConverter;
   backScanConverter.convert(postscan, prescanBack, 480);
 
-  // compute the absolute difference of the reference and the result
-  vpImage<unsigned char> sub(prescanBack.getHeight(), prescanBack.getWidth());
+  // compute the sum of square difference of the reference and the result
   int inc = 0;
-  for (int i = 0; i < prescanBack.getHeight(); i++) {
-    for (int j = 0; j < prescanBack.getWidth(); j++) {
+  int pxSkipped = 0;
+  for (unsigned int i = 0; i < prescanBack.getHeight(); i++) {
+    for (unsigned int j = 0; j < prescanBack.getWidth(); j++) {
       if (i > 3 && j > 3) { // we skip top & left borders, they have huge differencies compared to the rest of the image
-        inc += abs(prescanBack[i][j] - prescanReference[i][j]);
-        sub[i][j] = abs(prescanBack[i][j] - prescanReference[i][j]);
+        inc += (prescanBack[i][j] - prescanReference[i][j]) * (prescanBack[i][j] - prescanReference[i][j]);
+      } else {
+        pxSkipped++;
       }
     }
   }
-  if ((inc / (double)sub.getSize()) < 5) // we allow a mean difference of 5 units per pixels between the images
+  if ((sqrt(inc) / (double)(prescanReference.getSize() - pxSkipped)) <
+      0.5) // we allow a mean difference of 1 units per pixels between the images
     testFailed = false;
 
   if (!testFailed)

--- a/modules/ustk_core/test/scanConversion/testUsScanConversion.cpp
+++ b/modules/ustk_core/test/scanConversion/testUsScanConversion.cpp
@@ -37,8 +37,10 @@
 #include <visp3/core/vpDebug.h>
 #include <visp3/core/vpIoTools.h>
 
+#include <visp3/ustk_core/us.h>
 #include <visp3/ustk_core/usPostScanToPreScan2DConverter.h>
 #include <visp3/ustk_core/usPreScanToPostScan2DConverter.h>
+#include <visp3/ustk_io/usImageIo.h>
 
 #include <string>
 #include <vector>
@@ -52,60 +54,49 @@ int main(int argc, const char **argv)
   (void)argc;
   (void)argv;
 
-  /*bool testFailed = false;
-  if (argc!=2) {
-    std::cout << "Wrong number of arguments" << argc << std::endl;
-    exit (0); //to change when we have a dataset to provide for this test
-  }
-  std::cout << "Usage : ./testUsScanConversion2D /path/to/prescan2d "<<std::endl;
-  std::cout << "In this case you're going to convert the pre-scan image into post-scan,"
-               " and then convert it back to pre-scan." <<std::endl;
+  if (us::getDataSetPath().empty())
+    throw(vpException(vpException::fatalError, "Could not find ustk-dataset"));
 
-  std::cout <<  "-------------------------------------------------------" << std::endl ;
-  std::cout <<  "  testUsScanConversion2D.cpp" <<std::endl << std::endl ;
-  std::cout <<  "  The test converts a pre-scan image to post-scan, and converts it back to pre-scan."
-                "  Then it checks if the 2 pre-scan images are equal." << std::endl ;
-  std::cout <<  "-------------------------------------------------------" << std::endl ;
-  std::cout << std::endl ;
+  bool testFailed = true;
 
-  //pre-scan reading
+  std::cout << "-------------------------------------------------------" << std::endl;
+  std::cout << "  testUsScanConversion2D.cpp" << std::endl << std::endl;
+  std::cout << "  The test converts a pre-scan image to post-scan, and converts it back to pre-scan."
+               "  Then it checks if the 2 pre-scan images are equal."
+            << std::endl;
+  std::cout << "-------------------------------------------------------" << std::endl;
+  std::cout << std::endl;
+
+  // pre-scan reading
   usImagePreScan2D<unsigned char> prescanReference;
   usImagePostScan2D<unsigned char> postscan;
   usImagePreScan2D<unsigned char> prescanBack;
 
-  usImageIo::read(prescanReference, argv[1]);
-  prescanReference.setDepth(0.14784);
+  std::string preScanPath = us::getDataSetPath() + "/pre-scan/2D_xml/prescan2d.xml";
+
+  usImageIo::read(prescanReference, preScanPath);
 
   usPreScanToPostScan2DConverter scanConverter;
-  scanConverter.init(prescanReference.getBModeSampleNumber(),prescanReference.getScanLineNumber(),
-                     ustk::defaultSpeedOfSound, 0.0005,prescanReference.getTransducerRadius(),2500000.0,0.00042168,128);
-  scanConverter.run(postscanReference,prescanReference);*/
-  /*
-radius 0.04
-depth 0.14784
-APitch 0.000308
-LPitch 0.000425
-resolution 0.0005
-AN 480
-LN 128
-
-m_APitch = m_speedOfSound / (2.0 * samplingFrequency); => frequ = speed/(2*apitch) = 1540/0.000616 = 2500000
-m_LPitch = (pitch * nElements) / (LN-1); => pitch*NElts = Lpitch * (LN-1) = 0.000425 * 127 = 0.053975
-                     => nELts = 128 && pitch = 0.00042168
-
-
-*/
-  /*postscanReference.setDepth(0.14784);
-  usImageIo::write(postscanReference,vpIoTools::getParent(argv[1]).append("/aaa.xml"));
-
+  scanConverter.convert(prescanReference, postscan, 0.0005, 0.0005);
 
   usPostScanToPreScan2DConverter backScanConverter;
-  backScanConverter.init(postscanReference,480,128);
-  backScanConverter.run(postscanReference,prescanBack);
+  backScanConverter.convert(postscan, prescanBack, 480);
 
-  usImageIo::write(prescanBack,vpIoTools::getParent(argv[1]).append("/bbb.xml"));
+  // compute the absolute difference of the reference and the result
+  vpImage<unsigned char> sub(prescanBack.getHeight(), prescanBack.getWidth());
+  int inc = 0;
+  for (int i = 0; i < prescanBack.getHeight(); i++) {
+    for (int j = 0; j < prescanBack.getWidth(); j++) {
+      if (i > 3 && j > 3) { // we skip top & left borders, they have huge differencies compared to the rest of the image
+        inc += abs(prescanBack[i][j] - prescanReference[i][j]);
+        sub[i][j] = abs(prescanBack[i][j] - prescanReference[i][j]);
+      }
+    }
+  }
+  if ((inc / (double)sub.getSize()) < 5) // we allow a mean difference of 5 units per pixels between the images
+    testFailed = false;
 
-  if(!testFailed)
-    std::cout << "Test passed !" << std::endl;*/
-  return 0;
+  if (!testFailed)
+    std::cout << "Test passed !" << std::endl;
+  return testFailed;
 }

--- a/modules/ustk_grabber/include/visp3/ustk_grabber/usNetworkGrabber.h
+++ b/modules/ustk_grabber/include/visp3/ustk_grabber/usNetworkGrabber.h
@@ -52,7 +52,6 @@
 // Qt Network
 #include <QtCore/QObject>
 #include <QtCore/QThread>
-#include <QtCore/QThread>
 #include <QtNetwork/QHostAddress>
 #include <QtNetwork/QTcpSocket>
 
@@ -78,6 +77,13 @@ public:
     MOST_RECENT_FRAME_POSITION_IN_VEC = 1,
     CURRENT_FILLED_FRAME_POSITION_IN_VEC = 2
   } usDataPositionInBuffer;
+
+  /*! Enum to specify types of volumes to grab*/
+  typedef enum {
+    ODD = 0,     /*!< Grab only odd volumes */
+    EVEN = 1,    /*!< Grab only even volumes */
+    ODD_EVEN = 2 /*!< Grab every volumes */
+  } usVolumeField;
 
   // Following headers must be the same in the server (ultrasound station) !
 

--- a/modules/ustk_grabber/include/visp3/ustk_grabber/usNetworkGrabberPostScan2D.h
+++ b/modules/ustk_grabber/include/visp3/ustk_grabber/usNetworkGrabberPostScan2D.h
@@ -98,6 +98,7 @@ private:
   bool m_recordingOn;
   std::string m_recordingPath;
   usMHDSequenceWriter m_sequenceWriter;
+  uint64_t m_firstImageTimestamp;
 };
 
 #endif // QT4 || QT5

--- a/modules/ustk_grabber/include/visp3/ustk_grabber/usNetworkGrabberPreScan2D.h
+++ b/modules/ustk_grabber/include/visp3/ustk_grabber/usNetworkGrabberPreScan2D.h
@@ -103,6 +103,7 @@ private:
   // to manage the recording process
   bool m_recordingOn;
   usMHDSequenceWriter m_sequenceWriter;
+  uint64_t m_firstImageTimestamp;
 };
 
 #endif // QT4 || QT5

--- a/modules/ustk_grabber/include/visp3/ustk_grabber/usNetworkGrabberPreScan3D.h
+++ b/modules/ustk_grabber/include/visp3/ustk_grabber/usNetworkGrabberPreScan3D.h
@@ -113,6 +113,7 @@ private:
   // to manage the recording process
   bool m_recordingOn;
   usMHDSequenceWriter m_sequenceWriter;
+  uint64_t m_firstImageTimestamp;
 };
 
 #endif // QT4 || QT5

--- a/modules/ustk_grabber/include/visp3/ustk_grabber/usNetworkGrabberPreScan3D.h
+++ b/modules/ustk_grabber/include/visp3/ustk_grabber/usNetworkGrabberPreScan3D.h
@@ -83,6 +83,8 @@ public:
 
   bool isFirstFrameAvailable() { return m_firstFrameAvailable; }
 
+  void setVolumeField(usVolumeField volumeField);
+
   void stopRecording();
 
 signals:
@@ -114,6 +116,9 @@ private:
   bool m_recordingOn;
   usMHDSequenceWriter m_sequenceWriter;
   uint64_t m_firstImageTimestamp;
+
+  // volume selection
+  usNetworkGrabber::usVolumeField m_volumeField;
 };
 
 #endif // QT4 || QT5

--- a/modules/ustk_grabber/include/visp3/ustk_grabber/usNetworkGrabberRF2D.h
+++ b/modules/ustk_grabber/include/visp3/ustk_grabber/usNetworkGrabberRF2D.h
@@ -95,6 +95,7 @@ private:
   // to manage the recording process
   bool m_recordingOn;
   usMHDSequenceWriter m_sequenceWriter;
+  uint64_t m_firstImageTimestamp;
 };
 
 #endif // QT4 || QT5

--- a/modules/ustk_grabber/include/visp3/ustk_grabber/usNetworkGrabberRF3D.h
+++ b/modules/ustk_grabber/include/visp3/ustk_grabber/usNetworkGrabberRF3D.h
@@ -112,6 +112,7 @@ private:
   // to manage the recording process
   bool m_recordingOn;
   usMHDSequenceWriter m_sequenceWriter;
+  uint64_t m_firstImageTimestamp;
 };
 
 #endif // QT4 || QT5

--- a/modules/ustk_grabber/include/visp3/ustk_grabber/usNetworkGrabberRF3D.h
+++ b/modules/ustk_grabber/include/visp3/ustk_grabber/usNetworkGrabberRF3D.h
@@ -82,6 +82,8 @@ public:
 
   bool isFirstFrameAvailable() { return m_firstFrameAvailable; }
 
+  void setVolumeField(usVolumeField volumeField);
+
   void stopRecording();
 
 signals:
@@ -113,6 +115,9 @@ private:
   bool m_recordingOn;
   usMHDSequenceWriter m_sequenceWriter;
   uint64_t m_firstImageTimestamp;
+
+  // volume selection
+  usNetworkGrabber::usVolumeField m_volumeField;
 };
 
 #endif // QT4 || QT5

--- a/modules/ustk_grabber/src/usNetworkGrabberPostScan2D.cpp
+++ b/modules/ustk_grabber/src/usNetworkGrabberPostScan2D.cpp
@@ -53,6 +53,7 @@ usNetworkGrabberPostScan2D::usNetworkGrabberPostScan2D(usNetworkGrabber *parent)
   m_swichOutputInit = false;
 
   m_recordingOn = false;
+  m_firstImageTimestamp = 0;
 
   connect(m_tcpSocket, SIGNAL(readyRead()), this, SLOT(dataArrived()));
 }
@@ -113,6 +114,10 @@ void usNetworkGrabberPostScan2D::dataArrived()
     quint64 timestamp;
     in >> timestamp;
     m_imageHeader.timeStamp = timestamp;
+
+    if (m_imageHeader.frameCount == 0) // used to save the sequence
+      m_firstImageTimestamp = timestamp;
+
     in >> m_imageHeader.dataRate;
     in >> m_imageHeader.dataLength;
     in >> m_imageHeader.ss;
@@ -211,7 +216,8 @@ void usNetworkGrabberPostScan2D::dataArrived()
         m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC) = savePtr;
         if (m_recordingOn)
           m_sequenceWriter.write(*m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC),
-                                 m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getTimeStamp());
+                                 m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getTimeStamp() -
+                                     m_firstImageTimestamp);
       }
       m_firstFrameAvailable = true;
       emit(newFrameAvailable());
@@ -243,7 +249,8 @@ void usNetworkGrabberPostScan2D::dataArrived()
 
       if (m_recordingOn)
         m_sequenceWriter.write(*m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC),
-                               m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getTimeStamp());
+                               m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getTimeStamp() -
+                                   m_firstImageTimestamp);
 
       m_firstFrameAvailable = true;
       emit(newFrameAvailable());

--- a/modules/ustk_grabber/src/usNetworkGrabberPreScan2D.cpp
+++ b/modules/ustk_grabber/src/usNetworkGrabberPreScan2D.cpp
@@ -56,6 +56,7 @@ usNetworkGrabberPreScan2D::usNetworkGrabberPreScan2D(usNetworkGrabber *parent) :
   m_swichOutputInit = false;
 
   m_recordingOn = false;
+  m_firstImageTimestamp = 0;
 
   connect(m_tcpSocket, SIGNAL(readyRead()), this, SLOT(dataArrived()));
 }
@@ -116,6 +117,10 @@ void usNetworkGrabberPreScan2D::dataArrived()
     quint64 timestamp;
     in >> timestamp;
     m_imageHeader.timeStamp = timestamp;
+
+    if (m_imageHeader.frameCount == 0) // used to save the sequence
+      m_firstImageTimestamp = timestamp;
+
     in >> m_imageHeader.dataRate;
     in >> m_imageHeader.dataLength;
     in >> m_imageHeader.ss;
@@ -235,7 +240,8 @@ void usNetworkGrabberPreScan2D::invertRowsCols()
   m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC) = savePtr;
   if (m_recordingOn)
     m_sequenceWriter.write(*m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC),
-                           m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getTimeStamp());
+                           m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getTimeStamp() -
+                               m_firstImageTimestamp);
 
   m_firstFrameAvailable = true;
   emit(newFrameAvailable());

--- a/modules/ustk_grabber/src/usNetworkGrabberPreScan3D.cpp
+++ b/modules/ustk_grabber/src/usNetworkGrabberPreScan3D.cpp
@@ -59,6 +59,8 @@ usNetworkGrabberPreScan3D::usNetworkGrabberPreScan3D(usNetworkGrabber *parent)
   m_recordingOn = false;
   m_firstImageTimestamp = 0;
 
+  m_volumeField = usNetworkGrabber::ODD_EVEN;
+
   connect(m_tcpSocket, SIGNAL(readyRead()), this, SLOT(dataArrived()));
 }
 
@@ -327,6 +329,27 @@ usVolumeGrabbedInfo<usImagePreScan3D<unsigned char> > *usNetworkGrabberPreScan3D
     loop.connect(this, SIGNAL(newVolumeAvailable()), SLOT(quit()));
     loop.exec();
 
+    // check parity
+    bool parityControl = false;
+    if (m_volumeField == ODD) {
+      if (m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getVolumeCount() % 2 == 1) {
+        parityControl = true;
+      }
+    } else if (m_volumeField == EVEN) {
+      if (m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getVolumeCount() % 2 == 0) {
+        parityControl = true;
+      }
+    } else {
+      parityControl = true;
+    }
+
+    // if parity not ok, we wait next volume
+    if (!parityControl) {
+      QEventLoop loop;
+      loop.connect(this, SIGNAL(newVolumeAvailable()), SLOT(quit()));
+      loop.exec();
+    }
+
     // switch pointers
     usVolumeGrabbedInfo<usImagePreScan3D<unsigned char> > *savePtr = m_outputBuffer.at(OUTPUT_FRAME_POSITION_IN_VEC);
     m_outputBuffer.at(OUTPUT_FRAME_POSITION_IN_VEC) = m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC);
@@ -341,6 +364,27 @@ usVolumeGrabbedInfo<usImagePreScan3D<unsigned char> > *usNetworkGrabberPreScan3D
       loop.connect(this, SIGNAL(newVolumeAvailable()), SLOT(quit()));
       loop.exec();
 
+      // check parity
+      bool parityControl = false;
+      if (m_volumeField == ODD) {
+        if (m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getVolumeCount() % 2 == 1) {
+          parityControl = true;
+        }
+      } else if (m_volumeField == EVEN) {
+        if (m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getVolumeCount() % 2 == 0) {
+          parityControl = true;
+        }
+      } else {
+        parityControl = true;
+      }
+
+      // if parity not ok, we wait next volume
+      if (!parityControl) {
+        QEventLoop loop;
+        loop.connect(this, SIGNAL(newVolumeAvailable()), SLOT(quit()));
+        loop.exec();
+      }
+
       // switch pointers
       usVolumeGrabbedInfo<usImagePreScan3D<unsigned char> > *savePtr = m_outputBuffer.at(OUTPUT_FRAME_POSITION_IN_VEC);
       m_outputBuffer.at(OUTPUT_FRAME_POSITION_IN_VEC) = m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC);
@@ -352,6 +396,28 @@ usVolumeGrabbedInfo<usImagePreScan3D<unsigned char> > *usNetworkGrabberPreScan3D
     else if (m_outputBuffer.at(OUTPUT_FRAME_POSITION_IN_VEC)->getVolumeCount() <
                  m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getVolumeCount() ||
              !m_swichOutputInit) {
+
+      // check parity
+      bool parityControl = false;
+      if (m_volumeField == ODD) {
+        if (m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getVolumeCount() % 2 == 1) {
+          parityControl = true;
+        }
+      } else if (m_volumeField == EVEN) {
+        if (m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getVolumeCount() % 2 == 0) {
+          parityControl = true;
+        }
+      } else {
+        parityControl = true;
+      }
+
+      // if parity not ok, we wait next volume
+      if (!parityControl) {
+        QEventLoop loop;
+        loop.connect(this, SIGNAL(newVolumeAvailable()), SLOT(quit()));
+        loop.exec();
+      }
+
       // switch pointers (output <-> mostRecentFilled)
       usVolumeGrabbedInfo<usImagePreScan3D<unsigned char> > *savePtr = m_outputBuffer.at(OUTPUT_FRAME_POSITION_IN_VEC);
       m_outputBuffer.at(OUTPUT_FRAME_POSITION_IN_VEC) = m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC);
@@ -377,5 +443,14 @@ void usNetworkGrabberPreScan3D::activateRecording(std::string path)
 * Stop recording process.
 */
 void usNetworkGrabberPreScan3D::stopRecording() { m_recordingOn = false; }
+
+/**
+* Set recording to specific volumes : odd, even or both.
+* @param volumeField Type of volume to acquire (see usNetworkGrabber::usVolumeField enum).
+*/
+void usNetworkGrabberPreScan3D::setVolumeField(usNetworkGrabber::usVolumeField volumeField)
+{
+  m_volumeField = volumeField;
+}
 
 #endif

--- a/modules/ustk_grabber/src/usNetworkGrabberPreScan3D.cpp
+++ b/modules/ustk_grabber/src/usNetworkGrabberPreScan3D.cpp
@@ -57,6 +57,7 @@ usNetworkGrabberPreScan3D::usNetworkGrabberPreScan3D(usNetworkGrabber *parent)
   m_motorSweepingInZDirection = true;
 
   m_recordingOn = false;
+  m_firstImageTimestamp = 0;
 
   connect(m_tcpSocket, SIGNAL(readyRead()), this, SLOT(dataArrived()));
 }
@@ -117,6 +118,10 @@ void usNetworkGrabberPreScan3D::dataArrived()
     quint64 timestamp;
     in >> timestamp;
     m_imageHeader.timeStamp = timestamp;
+
+    if (m_imageHeader.frameCount == 0) // used to save the sequence
+      m_firstImageTimestamp = timestamp;
+
     in >> m_imageHeader.dataRate;
     in >> m_imageHeader.dataLength;
     in >> m_imageHeader.ss;
@@ -288,10 +293,13 @@ void usNetworkGrabberPreScan3D::includeFrameInVolume()
         m_outputBuffer.at(CURRENT_FILLED_FRAME_POSITION_IN_VEC);
     m_outputBuffer.at(CURRENT_FILLED_FRAME_POSITION_IN_VEC) = m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC);
     m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC) = savePtr;
-    if (m_recordingOn)
-      m_sequenceWriter.write(*m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC),
-                             m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getTimeStamps());
-
+    if (m_recordingOn) {
+      std::vector<uint64_t> timestampsToWrite;
+      for (unsigned int i = 0; i < m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getTimeStamps().size(); i++)
+        timestampsToWrite.push_back(m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getTimeStamps().at(i) -
+                                    m_firstImageTimestamp);
+      m_sequenceWriter.write(*m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC), timestampsToWrite);
+    }
     if (volumeIndex % 2 != 0) // case of backward moving motor (opposite to Z direction)
       m_motorSweepingInZDirection = true;
     else

--- a/modules/ustk_grabber/src/usNetworkGrabberRF2D.cpp
+++ b/modules/ustk_grabber/src/usNetworkGrabberRF2D.cpp
@@ -52,6 +52,7 @@ usNetworkGrabberRF2D::usNetworkGrabberRF2D(usNetworkGrabber *parent) : usNetwork
   m_swichOutputInit = false;
 
   m_recordingOn = false;
+  m_firstImageTimestamp = 0;
 
   connect(m_tcpSocket, SIGNAL(readyRead()), this, SLOT(dataArrived()));
 }
@@ -113,6 +114,10 @@ void usNetworkGrabberRF2D::dataArrived()
     quint64 timestamp;
     in >> timestamp;
     m_imageHeader.timeStamp = timestamp;
+
+    if (m_imageHeader.frameCount == 0) // used to save the sequence
+      m_firstImageTimestamp = timestamp;
+
     in >> m_imageHeader.dataRate;
     in >> m_imageHeader.dataLength;
     in >> m_imageHeader.ss;
@@ -199,7 +204,8 @@ void usNetworkGrabberRF2D::dataArrived()
       m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC) = savePtr;
       if (m_recordingOn)
         m_sequenceWriter.write(*m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC),
-                               m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getTimeStamp());
+                               m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getTimeStamp() -
+                                   m_firstImageTimestamp);
 
       m_firstFrameAvailable = true;
       emit(newFrameAvailable());
@@ -232,7 +238,8 @@ void usNetworkGrabberRF2D::dataArrived()
       m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC) = savePtr;
       if (m_recordingOn)
         m_sequenceWriter.write(*m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC),
-                               m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getTimeStamp());
+                               m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getTimeStamp() -
+                                   m_firstImageTimestamp);
 
       m_firstFrameAvailable = true;
       emit(newFrameAvailable());

--- a/modules/ustk_grabber/src/usNetworkGrabberRF3D.cpp
+++ b/modules/ustk_grabber/src/usNetworkGrabberRF3D.cpp
@@ -58,6 +58,8 @@ usNetworkGrabberRF3D::usNetworkGrabberRF3D(usNetworkGrabber *parent) : usNetwork
   m_recordingOn = false;
   m_firstImageTimestamp = 0;
 
+  m_volumeField = usNetworkGrabber::ODD_EVEN;
+
   connect(m_tcpSocket, SIGNAL(readyRead()), this, SLOT(dataArrived()));
 }
 
@@ -325,6 +327,27 @@ usVolumeGrabbedInfo<usImageRF3D<short int> > *usNetworkGrabberRF3D::acquire()
     loop.connect(this, SIGNAL(newVolumeAvailable()), SLOT(quit()));
     loop.exec();
 
+    // check parity
+    bool parityControl = false;
+    if (m_volumeField == ODD) {
+      if (m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getVolumeCount() % 2 == 1) {
+        parityControl = true;
+      }
+    } else if (m_volumeField == EVEN) {
+      if (m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getVolumeCount() % 2 == 0) {
+        parityControl = true;
+      }
+    } else {
+      parityControl = true;
+    }
+
+    // if parity not ok, we wait next volume
+    if (!parityControl) {
+      QEventLoop loop;
+      loop.connect(this, SIGNAL(newVolumeAvailable()), SLOT(quit()));
+      loop.exec();
+    }
+
     // switch pointers
     usVolumeGrabbedInfo<usImageRF3D<short int> > *savePtr = m_outputBuffer.at(OUTPUT_FRAME_POSITION_IN_VEC);
     m_outputBuffer.at(OUTPUT_FRAME_POSITION_IN_VEC) = m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC);
@@ -333,11 +356,35 @@ usVolumeGrabbedInfo<usImageRF3D<short int> > *usNetworkGrabberRF3D::acquire()
   } else {
     // user grabs too fast
     if (m_outputBuffer.at(OUTPUT_FRAME_POSITION_IN_VEC)->getVolumeCount() ==
-        m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getVolumeCount() + 1) {
+            m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getVolumeCount() + 1 ||
+        ((m_outputBuffer.at(OUTPUT_FRAME_POSITION_IN_VEC)->getVolumeCount() ==
+          m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getVolumeCount() + 2) &&
+         (m_volumeField == ODD || m_volumeField == EVEN))) {
       // we wait until a new frame is available
       QEventLoop loop;
       loop.connect(this, SIGNAL(newVolumeAvailable()), SLOT(quit()));
       loop.exec();
+
+      // check parity
+      bool parityControl = false;
+      if (m_volumeField == ODD) {
+        if (m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getVolumeCount() % 2 == 1) {
+          parityControl = true;
+        }
+      } else if (m_volumeField == EVEN) {
+        if (m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getVolumeCount() % 2 == 0) {
+          parityControl = true;
+        }
+      } else {
+        parityControl = true;
+      }
+
+      // if parity not ok, we wait next volume
+      if (!parityControl) {
+        QEventLoop loop;
+        loop.connect(this, SIGNAL(newVolumeAvailable()), SLOT(quit()));
+        loop.exec();
+      }
 
       // switch pointers
       usVolumeGrabbedInfo<usImageRF3D<short int> > *savePtr = m_outputBuffer.at(OUTPUT_FRAME_POSITION_IN_VEC);
@@ -350,6 +397,28 @@ usVolumeGrabbedInfo<usImageRF3D<short int> > *usNetworkGrabberRF3D::acquire()
     else if (m_outputBuffer.at(OUTPUT_FRAME_POSITION_IN_VEC)->getVolumeCount() <
                  m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getVolumeCount() ||
              !m_swichOutputInit) {
+
+      // check parity
+      bool parityControl = false;
+      if (m_volumeField == ODD) {
+        if (m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getVolumeCount() % 2 == 1) {
+          parityControl = true;
+        }
+      } else if (m_volumeField == EVEN) {
+        if (m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getVolumeCount() % 2 == 0) {
+          parityControl = true;
+        }
+      } else {
+        parityControl = true;
+      }
+
+      // if parity not ok, we wait next volume
+      if (!parityControl) {
+        QEventLoop loop;
+        loop.connect(this, SIGNAL(newVolumeAvailable()), SLOT(quit()));
+        loop.exec();
+      }
+
       // switch pointers (output <-> mostRecentFilled)
       usVolumeGrabbedInfo<usImageRF3D<short int> > *savePtr = m_outputBuffer.at(OUTPUT_FRAME_POSITION_IN_VEC);
       m_outputBuffer.at(OUTPUT_FRAME_POSITION_IN_VEC) = m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC);
@@ -377,4 +446,9 @@ void usNetworkGrabberRF3D::activateRecording(std::string path)
 */
 void usNetworkGrabberRF3D::stopRecording() { m_recordingOn = false; }
 
+/**
+* Set recording to specific volumes : odd, even or both.
+* @param volumeField Type of volume to acquire (see usNetworkGrabber::usVolumeField enum).
+*/
+void usNetworkGrabberRF3D::setVolumeField(usNetworkGrabber::usVolumeField volumeField) { m_volumeField = volumeField; }
 #endif

--- a/modules/ustk_io/include/visp3/ustk_io/usMHDSequenceReader.h
+++ b/modules/ustk_io/include/visp3/ustk_io/usMHDSequenceReader.h
@@ -126,6 +126,8 @@ public:
   uint64_t getNextTimeStamp();
   std::vector<uint64_t> getNextTimeStamps();
 
+  int getTotalImageNumber() const;
+
   void setSequenceDirectory(const std::string sequenceDirectory);
 
 private:

--- a/modules/ustk_io/src/usImageIo.cpp
+++ b/modules/ustk_io/src/usImageIo.cpp
@@ -428,7 +428,6 @@ void usImageIo::read(usImagePreScan2D<unsigned char> &preScanImage, const std::s
     preScanImage.setDepth(xmlSettings.getAxialResolution() * preScanImage.getHeight());
     preScanImage.setSamplingFrequency(xmlSettings.getTransducerSettings().getSamplingFrequency());
     preScanImage.setTransmitFrequency(xmlSettings.getTransducerSettings().getTransmitFrequency());
-    preScanImage.setDepth(xmlSettings.getAxialResolution() * preScanImage.getHeight());
 #else
     throw(vpException(vpException::fatalError, "Requires xml2 library"));
 #endif // VISP_HAVE_XML2

--- a/modules/ustk_io/src/usMHDSequenceReader.cpp
+++ b/modules/ustk_io/src/usMHDSequenceReader.cpp
@@ -402,6 +402,12 @@ std::vector<uint64_t> usMHDSequenceReader::getNextTimeStamps()
 int usMHDSequenceReader::getImageNumber() const { return m_imageCounter; }
 
 /**
+* Returns the total image number in sequence.
+* @return The total image number (total volume number for 3D sequences, total frame number for 2D sequences).
+*/
+int usMHDSequenceReader::getTotalImageNumber() const { return m_totalImageNumber; }
+
+/**
 * Acquisition method for specific image in the sequence for usImageRF2D : fills the output image with the next volume in
 * the sequence.
 * @param [in] imageNumber Image number in sequence to acquire (from 0 to total image number - 1)

--- a/tutorial/ustk/sonosite/tutorial-sonosite-confidence-map.cpp
+++ b/tutorial/ustk/sonosite/tutorial-sonosite-confidence-map.cpp
@@ -111,7 +111,7 @@ vpThread::Return displayFunction(vpThread::Args args)
 
       // Convert post-scan to pre-scan image
       usPostScanToPreScan2DConverter backConverter_;
-      backConverter_.convert(postScan_, preScan_);
+      backConverter_.convert(postScan_, preScan_, 480);
 
       // Compute confidence map on pre-scan image
       // initialisations

--- a/tutorial/ustk/virtualServerClients/tutorial-ustk-virtual-server-RF2D.cpp
+++ b/tutorial/ustk/virtualServerClients/tutorial-ustk-virtual-server-RF2D.cpp
@@ -28,6 +28,12 @@ int main(int argc, char **argv)
   qtGrabber->setIPAddress("127.0.0.1"); // local loop, server must be running on same computer
   qtGrabber->connectToServer();
 
+  // record option
+  if (qApp->arguments().contains(QString("--output"))) {
+    qtGrabber->activateRecording(
+        qApp->arguments().at(qApp->arguments().indexOf(QString("--output")) + 1).toStdString());
+  }
+
   // setting acquisition parameters
   usNetworkGrabber::usInitHeaderSent header;
   header.probeId = 0;      // 4DC7 id = 15

--- a/tutorial/ustk/virtualServerClients/tutorial-ustk-virtual-server-postScan2D.cpp
+++ b/tutorial/ustk/virtualServerClients/tutorial-ustk-virtual-server-postScan2D.cpp
@@ -27,6 +27,12 @@ int main(int argc, char **argv)
   qtGrabber->setIPAddress("127.0.0.1"); // local loop, server must be running on same computer
   qtGrabber->connectToServer();
 
+  // record option
+  if (qApp->arguments().contains(QString("--output"))) {
+    qtGrabber->activateRecording(
+        qApp->arguments().at(qApp->arguments().indexOf(QString("--output")) + 1).toStdString());
+  }
+
   // setting acquisition parameters
   usNetworkGrabber::usInitHeaderSent header;
   header.probeId = 0;     // 4DC7 id = 15

--- a/tutorial/ustk/virtualServerClients/tutorial-ustk-virtual-server-preScan2D.cpp
+++ b/tutorial/ustk/virtualServerClients/tutorial-ustk-virtual-server-preScan2D.cpp
@@ -27,6 +27,12 @@ int main(int argc, char **argv)
   qtGrabber->setIPAddress("127.0.0.1"); // local loop, server must be running on same computer
   qtGrabber->connectToServer();
 
+  // record option
+  if (qApp->arguments().contains(QString("--output"))) {
+    qtGrabber->activateRecording(
+        qApp->arguments().at(qApp->arguments().indexOf(QString("--output")) + 1).toStdString());
+  }
+
   // setting acquisition parameters
   usNetworkGrabber::usInitHeaderSent header;
   header.probeId = 0;     // 4DC7 id = 15


### PR DESCRIPTION
Some options added for virtual server application: 
- Pause option on volume sequences: send volume V, V+1, V, V+1, ... 
- Rewind option for all types of image sequences (2D and 3D): once at the end of the sequence we rewind to the first, then to the last, then back to the first, ...

Grabbers updates:
- For volumes, we can now choose to grab only odd or even volumes
- When we activate the recording with activateRecording mehod, the images timestamps saved starts at 0