### PR TITLE
Fix 3D US grabbing

### DIFF
--- a/modules/ustk_core/include/visp3/ustk_core/usImagePreScan3D.h
+++ b/modules/ustk_core/include/visp3/ustk_core/usImagePreScan3D.h
@@ -346,7 +346,7 @@ template <class Type> void usImagePreScan3D<Type>::getFrame(usImagePreScan2D<Typ
 
   // offset to access the frame in the volume
   int offset = index * this->getHeight() * this->getWidth();
-  Type *frameBeginning = this->getData() + offset;
+  const Type *frameBeginning = this->getConstData() + offset;
 
   // copy
   for (unsigned int i = 0; i < this->getWidth(); i++) {

--- a/modules/ustk_core/include/visp3/ustk_core/usImageRF3D.h
+++ b/modules/ustk_core/include/visp3/ustk_core/usImageRF3D.h
@@ -233,7 +233,7 @@ usImageRF3D<Type>::usImageRF3D(const usImageRF3D &other)
   : usImagePreScanSettings(other), usMotorSettings(other), m_width(0), m_height(0), m_numberOfFrames(0), m_size(0),
     bitmap(NULL)
 {
-  init(other.getWidth(), other.getHeight(), other.getNumberOfFrames());
+  init(other.getHeight(), other.getWidth(), other.getNumberOfFrames());
   memcpy(bitmap, other.getConstData(), (size_t)(m_width * m_height * m_numberOfFrames * sizeof(Type)));
 }
 
@@ -259,7 +259,7 @@ template <class Type> usImageRF3D<Type>::~usImageRF3D()
 template <class Type> usImageRF3D<Type> &usImageRF3D<Type>::operator=(const usImageRF3D<Type> &other)
 {
   // allocation and resize
-  resize(other.getWidth(), other.getHeight(), other.getNumberOfFrames());
+  resize(other.getHeight(), other.getWidth(), other.getNumberOfFrames());
 
   // filling voxel values
   memcpy(bitmap, other.getConstData(), (size_t)(m_width * m_height * m_numberOfFrames * sizeof(Type)));
@@ -327,7 +327,7 @@ template <class Type> unsigned int usImageRF3D<Type>::getRFSampleNumber() const 
 template <class Type> void usImageRF3D<Type>::setScanLineNumber(unsigned int scanLineNumber)
 {
   if (scanLineNumber != m_width)
-    resize(scanLineNumber, getHeight(), getNumberOfFrames());
+    resize(getHeight(), scanLineNumber, getNumberOfFrames());
   usTransducerSettings::setScanLineNumber(scanLineNumber);
 }
 
@@ -340,7 +340,7 @@ template <class Type> void usImageRF3D<Type>::setScanLineNumber(unsigned int sca
 template <class Type> void usImageRF3D<Type>::setFrameNumber(unsigned int frameNumber)
 {
   if (frameNumber != m_numberOfFrames)
-    resize(getWidth(), getHeight(), frameNumber);
+    resize(getHeight(), getWidth(), frameNumber);
   usMotorSettings::setFrameNumber(frameNumber);
 }
 

--- a/modules/ustk_core/include/visp3/ustk_core/usPreScanToPostScan3DConverter.h
+++ b/modules/ustk_core/include/visp3/ustk_core/usPreScanToPostScan3DConverter.h
@@ -53,9 +53,11 @@
  * This class allows to convert 3D pre-scan ultrasound images to post-scan.
  * The converter can be initialized through init() and then applied through convert().
  * This class accepts only images acquired by a convex transducer and a tilting motor for now.
- *
- * @warning Converting with this class uses a lot of RAM when computing the LUTs in init().
- *
+ * The optimization method used to perform the conversion can be set through setConverterOptimizationMethod() before the call to init().
+ * 
+ * @warning Converting with *_REDUCED_LOOKUP_TABLE or *_FULL_LOOKUP_TABLE optimizations method can use a lot of RAM when computing the LUTs in init().
+ * @warning Converting with *_DIRECT_CONVERSION optimization methods can lead to long conversion time.
+ * 
  * Considering the following usImagePreScan3D image as input:
  * \image html img-usImagePreScan3D.png
  * this class generates an usImagePostScan3D (convex or linear) as output:
@@ -75,7 +77,7 @@ int main()
   unsigned int frames = 10;
   double transducerRadius = 0.045;
   double scanLinePitch = 0.0012;
-  unsigned int scanLineNumber = 256;
+  unsigned int scanLineNumber = width;
   bool isTransducerConvex = true;
   double axialResolution = 0.002;
   double framePitch = 0.002;
@@ -105,6 +107,18 @@ int main()
  */
 class VISP_EXPORT usPreScanToPostScan3DConverter
 {
+public:
+  typedef enum {
+    SINGLE_THREAD_DIRECT_CONVERSION,
+    MULTI_THREAD_DIRECT_CONVERSION,
+    GPU_DIRECT_CONVERSION,
+    SINGLE_THREAD_FULL_LOOKUP_TABLE,
+    MULTI_THREAD_FULL_LOOKUP_TABLE,
+    GPU_FULL_LOOKUP_TABLE,
+    SINGLE_THREAD_REDUCED_LOOKUP_TABLE,
+    MULTI_THREAD_REDUCED_LOOKUP_TABLE,
+    GPU_REDUCED_LOOKUP_TABLE
+  } usConverterOptimizationMethod;
 protected:
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
   class usVoxelWeightAndIndex
@@ -114,9 +128,20 @@ protected:
     unsigned int m_inputIndex[8];
     double m_W[8];
   };
+  class usVoxelWeightAndIndexReducedMemory
+  {
+      friend class usPreScanToPostScan3DConverter;
+      unsigned int m_outputIndex;
+      unsigned int m_inputIndex;
+      double m_W[3];
+  };
 #endif
-  std::vector<usVoxelWeightAndIndex> m_lookupTable1;
-  std::vector<usVoxelWeightAndIndex> m_lookupTable2;
+  
+  usConverterOptimizationMethod m_converterOptimizationMethod;
+  usConverterOptimizationMethod m_conversionOptimizationMethodUsedAtInit;
+
+  std::vector<usVoxelWeightAndIndex> m_lookupTables[2];
+  std::vector<usVoxelWeightAndIndexReducedMemory> m_reducedLookupTables[2];
 
   usImagePreScan3D<unsigned char> m_VpreScan;
 
@@ -139,6 +164,9 @@ public:
 
   void init(const usImagePreScan3D<unsigned char> &preScanImage, double down = 1);
 
+  void setConverterOptimizationMethod(usConverterOptimizationMethod method);
+  usConverterOptimizationMethod setConverterOptimizationMethod() const {return m_converterOptimizationMethod;}
+  
   double getResolution() const { return m_resolution; }
 
   void SweepInZdirection(bool flag) { m_SweepInZdirection = flag; }

--- a/modules/ustk_core/include/visp3/ustk_core/usPreScanToPostScan3DConverter.h
+++ b/modules/ustk_core/include/visp3/ustk_core/usPreScanToPostScan3DConverter.h
@@ -119,8 +119,8 @@ protected:
   std::vector<usVoxelWeightAndIndex> m_lookupTable2;
 
   usImagePreScan3D<unsigned char> m_VpreScan;
-  usImagePostScan3D<unsigned char> m_VpostScan;
 
+  double m_downSamplingFactor;
   double m_resolution;
   bool m_SweepInZdirection;
 
@@ -132,20 +132,14 @@ protected:
 
 public:
   usPreScanToPostScan3DConverter();
-  usPreScanToPostScan3DConverter(const usImagePreScan3D<unsigned char> &preScanImage, int down);
+  usPreScanToPostScan3DConverter(const usImagePreScan3D<unsigned char> &preScanImage, double down);
   virtual ~usPreScanToPostScan3DConverter();
 
-  void convert(usImagePostScan3D<unsigned char> &postScanImage, const usImagePreScan3D<unsigned char> &preScanImage,
-               int downSamplingFactor = 1);
+  void convert(usImagePostScan3D<unsigned char> &postScanImage, const usImagePreScan3D<unsigned char> &preScanImage);
 
-  void init(const usImagePreScan3D<unsigned char> &preScanImage, int down = 1);
+  void init(const usImagePreScan3D<unsigned char> &preScanImage, double down = 1);
 
-  double getResolution() const;
-
-  void getVolume(usImagePostScan3D<unsigned char> &V);
-  usImagePostScan3D<unsigned char> getVolume();
-
-  double getResolution() { return m_resolution; }
+  double getResolution() const { return m_resolution; }
 
   void SweepInZdirection(bool flag) { m_SweepInZdirection = flag; }
 

--- a/modules/ustk_core/src/RFConversion/usRFToPreScan3DConverter.cpp
+++ b/modules/ustk_core/src/RFConversion/usRFToPreScan3DConverter.cpp
@@ -70,7 +70,7 @@ void usRFToPreScan3DConverter::convert(const usImageRF3D<short int> &rfImage,
       (((int)rfImage.getHeight()) != m_heightRF) || (((int)rfImage.getWidth()) != m_widthRF)) {
     init(rfImage.getHeight(), rfImage.getWidth(), rfImage.getNumberOfFrames());
   }
-  preScanImage.resize(rfImage.getHeight(), rfImage.getWidth() / getDecimationFactor(), rfImage.getNumberOfFrames());
+  preScanImage.resize(rfImage.getHeight() / getDecimationFactor(), rfImage.getWidth(), rfImage.getNumberOfFrames());
   // First we copy the transducer/motor settings
   preScanImage.setImagePreScanSettings(rfImage);
   preScanImage.setAxialResolution(rfImage.getDepth() / preScanImage.getHeight());
@@ -126,8 +126,10 @@ void usRFToPreScan3DConverter::init(int heightRF, int widthRF, int frameNumber)
   // first init
   if (!m_isInit) {
     m_converter = new usRFToPreScan2DConverter[frameNumber];
-    for (int i = 0; i < frameNumber; i++)
+    for (int i = 0; i < frameNumber; i++) {
       m_converter[i].init(widthRF, heightRF);
+      m_converter[i].setDecimationFactor(m_decimationFactor);
+    }
 
     m_isInit = true;
     m_frameNumber = frameNumber;
@@ -143,8 +145,10 @@ void usRFToPreScan3DConverter::init(int heightRF, int widthRF, int frameNumber)
     m_heightRF = heightRF;
     m_widthRF = widthRF;
     m_converter = new usRFToPreScan2DConverter[m_frameNumber];
-    for (int i = 0; i < m_frameNumber; i++)
+    for (int i = 0; i < m_frameNumber; i++) {
       m_converter[i].init(m_widthRF, m_heightRF);
+      m_converter[i].setDecimationFactor(m_decimationFactor);
+    }
   }
 }
 #endif

--- a/modules/ustk_core/src/scanConversion/usPreScanToPostScan3DConverter.cpp
+++ b/modules/ustk_core/src/scanConversion/usPreScanToPostScan3DConverter.cpp
@@ -226,7 +226,7 @@ void usPreScanToPostScan3DConverter::init(const usImagePreScan3D<unsigned char> 
 #ifdef VISP_HAVE_OPENMP
 #pragma omp parallel for
 #endif
-          for (unsigned int z = 0; z < m_nbZ; z++) {
+          for (int z = 0; z < (int)m_nbZ; z++) {
             double zz = m_resolution * z - zmax;
             double i, j, k;
             usPreScanToPostScan3DConverter::convertPostScanCoordToPreScanCoord(yy, xx, zz, &j, &i, &k, sweepingDirection==0);
@@ -361,7 +361,7 @@ void usPreScanToPostScan3DConverter::init(const usImagePreScan3D<unsigned char> 
 #ifdef VISP_HAVE_OPENMP
 #pragma omp parallel for
 #endif
-          for (unsigned int z = 0; z < m_nbZ; z++) {
+          for (int z = 0; z < (int)m_nbZ; z++) {
             double zz = m_resolution * z - zmax;
             double i, j, k;
             usPreScanToPostScan3DConverter::convertPostScanCoordToPreScanCoord(yy, xx, zz, &j, &i, &k, sweepingDirection==0);
@@ -531,7 +531,7 @@ void usPreScanToPostScan3DConverter::convert(usImagePostScan3D<unsigned char> &p
 #ifdef VISP_HAVE_OPENMP
 #pragma omp parallel for
 #endif
-        for (unsigned int z = 0; z < m_nbZ; z++) {
+        for (int z = 0; z < (int)m_nbZ; z++) {
           double zz = m_resolution * z - zmax;
           double i, j, k;
           usPreScanToPostScan3DConverter::convertPostScanCoordToPreScanCoord(yy, xx, zz, &j, &i, &k, m_SweepInZdirection);

--- a/modules/ustk_core/src/scanConversion/usPreScanToPostScan3DConverter.cpp
+++ b/modules/ustk_core/src/scanConversion/usPreScanToPostScan3DConverter.cpp
@@ -40,7 +40,7 @@
  * Default constructor.
  */
 usPreScanToPostScan3DConverter::usPreScanToPostScan3DConverter()
-  : m_VpreScan(), m_downSamplingFactor(1), m_resolution(), m_SweepInZdirection(true), m_initDone(false)
+  : m_converterOptimizationMethod(SINGLE_THREAD_REDUCED_LOOKUP_TABLE), m_conversionOptimizationMethodUsedAtInit(SINGLE_THREAD_DIRECT_CONVERSION), m_VpreScan(), m_downSamplingFactor(1), m_resolution(), m_SweepInZdirection(true), m_initDone(false)
 {
 }
 
@@ -70,14 +70,14 @@ void usPreScanToPostScan3DConverter::init(const usImagePreScan3D<unsigned char> 
   if (down <= 0)
     throw(vpException(vpException::badValue, "downsampling factor should b positive"));
   
-  
   // compare pre-scan image parameters, to avoid recomputing all the init process if parameters are the same
   if (((usMotorSettings)m_VpreScan) == ((usMotorSettings)preScanImage) &&
       ((usImagePreScanSettings)m_VpreScan) == ((usImagePreScanSettings)preScanImage) &&
       m_VpreScan.getWidth() == preScanImage.getWidth() && m_VpreScan.getHeight() == preScanImage.getHeight() &&
       m_VpreScan.getNumberOfFrames() == preScanImage.getNumberOfFrames() &&
       m_resolution == down * m_VpreScan.getAxialResolution() &&
-      m_downSamplingFactor == down) {
+      m_downSamplingFactor == down &&
+      m_converterOptimizationMethod == m_conversionOptimizationMethodUsedAtInit) {
     m_VpreScan = preScanImage; // update image content
     return;
   }
@@ -107,136 +107,300 @@ void usPreScanToPostScan3DConverter::init(const usImagePreScan3D<unsigned char> 
   unsigned int nbXY = m_nbX * m_nbY;
   unsigned int XY = X * Y;
   
-  try
+  // empty the lookup tables
+  if(m_lookupTables[0].size()>0) std::vector<usVoxelWeightAndIndex>().swap(m_lookupTables[0]);
+  if(m_lookupTables[1].size()>0) std::vector<usVoxelWeightAndIndex>().swap(m_lookupTables[1]);
+  if(m_reducedLookupTables[0].size()>0) std::vector<usVoxelWeightAndIndexReducedMemory>().swap(m_reducedLookupTables[0]);
+  if(m_reducedLookupTables[1].size()>0) std::vector<usVoxelWeightAndIndexReducedMemory>().swap(m_reducedLookupTables[1]);  
+  
+  switch(m_converterOptimizationMethod)
   {
-      long int LUTmaxSize = (long int)m_nbX*(long int)m_nbY*(long int)m_nbZ;
-      if(m_lookupTable1.size()>0) m_lookupTable1.clear();
-      if(m_lookupTable2.size()>0) m_lookupTable2.clear();
-      // reserve to avoid reallocation during the LUT filling
-      m_lookupTable1.reserve(LUTmaxSize);
-      m_lookupTable2.reserve(LUTmaxSize);
-  }
-  catch(std::exception &e)
+  case SINGLE_THREAD_DIRECT_CONVERSION:
   {
-      throw vpException(vpException::ioError, "usPreScanToPostScan3DConverter::init: %s \n Volume should maybe be downsampled", e.what());
+    break;
   }
+  case MULTI_THREAD_DIRECT_CONVERSION:
+  {
+    break;
+  }
+  case GPU_DIRECT_CONVERSION:
+  {
+    throw vpException(vpException::notImplementedError, "usPreScanToPostScan3DConverter::init: using method GPU_DIRECT_CONVERSION is not implemented yet");
+    break;
+  }
+  case SINGLE_THREAD_FULL_LOOKUP_TABLE:
+  {
+    try
+    {
+        long int LUTmaxSize = (long int)m_nbX*(long int)m_nbY*(long int)m_nbZ;
+        // reserve to avoid reallocation during the LUT filling
+        m_lookupTables[0].reserve(LUTmaxSize);
+        m_lookupTables[1].reserve(LUTmaxSize);
+    }
+    catch(std::exception &e)
+    {
+        throw vpException(vpException::ioError, "usPreScanToPostScan3DConverter::init: using method SINGLE_THREAD_FULL_LOOKUP_TABLE leads to %s \n Use another optimization method or downsample the volume", e.what());
+    }
+    for(unsigned int sweepingDirection=0 ; sweepingDirection<2 ; sweepingDirection++) {
+      for (unsigned int x = 0; x < m_nbX; x++) {
+        double xx = m_resolution * x - xmax;
+        for (unsigned int y = 0; y < m_nbY; y++) {
+          double yy = ymin + m_resolution * y;
+          for (unsigned int z = 0; z < m_nbZ; z++) {
+            double zz = m_resolution * z - zmax;
+            double i, j, k;
+            usPreScanToPostScan3DConverter::convertPostScanCoordToPreScanCoord(yy, xx, zz, &j, &i, &k, sweepingDirection==0);
+    
+            double ii = floor(i);
+            double jj = floor(j);
+            double kk = floor(k);
+    
+            if (ii >= 0 && jj >= 0 && kk >= 0 && ii + 1 < X && jj + 1 < Y && kk + 1 < Z) {
+              usVoxelWeightAndIndex m;
+              
+              m.m_outputIndex = x + m_nbX * y + nbXY * z;
+    
+              double u = i - ii;
+              double v = j - jj;
+              double w = k - kk;
+              double u1 = 1 - u;
+              double v1 = 1 - v;
+              double w1 = 1 - w;
+    
+              double v1w1 = v1 * w1;
+              double vw1 = v * w1;
+              double v1w = v1 * w;
+              double vw = v * w;
+    
+              m.m_W[0] = u1 * v1w1;
+              m.m_W[1] = u * v1w1;
+              m.m_W[2] = u1 * vw1;
+              m.m_W[3] = u * vw1;
+              m.m_W[4] = u1 * v1w;
+              m.m_W[5] = u * v1w;
+              m.m_W[6] = u1 * vw;
+              m.m_W[7] = u * vw;
+    
+              double Xjj = X * jj;
+              double Xjj1 = X * (jj + 1);
+              double XYKK = XY * kk;
+              double XYKK1 = XY * (kk + 1);
+    
+              m.m_inputIndex[0] = (unsigned int)(ii + Xjj + XYKK);
+              m.m_inputIndex[1] = (unsigned int)(ii + 1 + Xjj + XYKK);
+              m.m_inputIndex[2] = (unsigned int)(ii + Xjj1 + XYKK);
+              m.m_inputIndex[3] = (unsigned int)(ii + 1 + Xjj1 + XYKK);
+              m.m_inputIndex[4] = (unsigned int)(ii + Xjj + XYKK1);
+              m.m_inputIndex[5] = (unsigned int)(ii + 1 + Xjj + XYKK1);
+              m.m_inputIndex[6] = (unsigned int)(ii + Xjj1 + XYKK1);
+              m.m_inputIndex[7] = (unsigned int)(ii + 1 + Xjj1 + XYKK1);
 
-  for (unsigned int x = 0; x < m_nbX; x++) {
-    double xx = m_resolution * x - xmax;
-    for (unsigned int y = 0; y < m_nbY; y++) {
-      double yy = ymin + m_resolution * y;
-      #ifdef VISP_HAVE_OPENMP
-      #pragma omp parallel for
-      #endif
-      for (unsigned int z = 0; z < m_nbZ; z++) {
-        double zz = m_resolution * z - zmax;
-        double i, j, k;
-        usPreScanToPostScan3DConverter::convertPostScanCoordToPreScanCoord(yy, xx, zz, &j, &i, &k, true);
-
-        double ii = floor(i);
-        double jj = floor(j);
-        double kk = floor(k);
-
-        if (ii >= 0 && jj >= 0 && kk >= 0 && ii + 1 < X && jj + 1 < Y && kk + 1 < Z) {
-          usVoxelWeightAndIndex m;
-          
-          m.m_outputIndex = x + m_nbX * y + nbXY * z;
-
-          double u = i - ii;
-          double v = j - jj;
-          double w = k - kk;
-          double u1 = 1 - u;
-          double v1 = 1 - v;
-          double w1 = 1 - w;
-
-          double v1w1 = v1 * w1;
-          double vw1 = v * w1;
-          double v1w = v1 * w;
-          double vw = v * w;
-
-          m.m_W[0] = u1 * v1w1;
-          m.m_W[1] = u * v1w1;
-          m.m_W[2] = u1 * vw1;
-          m.m_W[3] = u * vw1;
-          m.m_W[4] = u1 * v1w;
-          m.m_W[5] = u * v1w;
-          m.m_W[6] = u1 * vw;
-          m.m_W[7] = u * vw;
-
-          double Xjj = X * jj;
-          double Xjj1 = X * (jj + 1);
-          double XYKK = XY * kk;
-          double XYKK1 = XY * (kk + 1);
-
-          m.m_inputIndex[0] = (unsigned int)(ii + Xjj + XYKK);
-          m.m_inputIndex[1] = (unsigned int)(ii + 1 + Xjj + XYKK);
-          m.m_inputIndex[2] = (unsigned int)(ii + Xjj1 + XYKK);
-          m.m_inputIndex[3] = (unsigned int)(ii + 1 + Xjj1 + XYKK);
-          m.m_inputIndex[4] = (unsigned int)(ii + Xjj + XYKK1);
-          m.m_inputIndex[5] = (unsigned int)(ii + 1 + Xjj + XYKK1);
-          m.m_inputIndex[6] = (unsigned int)(ii + Xjj1 + XYKK1);
-          m.m_inputIndex[7] = (unsigned int)(ii + 1 + Xjj1 + XYKK1);
-          #ifdef VISP_HAVE_OPENMP
-          #pragma omp critical
-          #endif
-          m_lookupTable1.push_back(m);
-        }
-
-        usPreScanToPostScan3DConverter::convertPostScanCoordToPreScanCoord(yy, xx, zz, &j, &i, &k, false);
-
-        ii = floor(i);
-        jj = floor(j);
-        kk = floor(k);
-
-        if (ii >= 0 && jj >= 0 && kk >= 0 && ii + 1 < X && jj + 1 < Y && kk + 1 < Z) {
-          usVoxelWeightAndIndex m;
-
-          m.m_outputIndex = x + m_nbX * y + nbXY * z;
-
-          double u = i - ii;
-          double v = j - jj;
-          double w = k - kk;
-          double u1 = 1 - u;
-          double v1 = 1 - v;
-          double w1 = 1 - w;
-
-          double v1w1 = v1 * w1;
-          double vw1 = v * w1;
-          double v1w = v1 * w;
-          double vw = v * w;
-
-          m.m_W[0] = u1 * v1w1;
-          m.m_W[1] = u * v1w1;
-          m.m_W[2] = u1 * vw1;
-          m.m_W[3] = u * vw1;
-          m.m_W[4] = u1 * v1w;
-          m.m_W[5] = u * v1w;
-          m.m_W[6] = u1 * vw;
-          m.m_W[7] = u * vw;
-
-          double Xjj = X * jj;
-          double Xjj1 = X * (jj + 1);
-          double XYKK = XY * kk;
-          double XYKK1 = XY * (kk + 1);
-
-          m.m_inputIndex[0] = (unsigned int)(ii + Xjj + XYKK);
-          m.m_inputIndex[1] = (unsigned int)(ii + 1 + Xjj + XYKK);
-          m.m_inputIndex[2] = (unsigned int)(ii + Xjj1 + XYKK);
-          m.m_inputIndex[3] = (unsigned int)(ii + 1 + Xjj1 + XYKK);
-          m.m_inputIndex[4] = (unsigned int)(ii + Xjj + XYKK1);
-          m.m_inputIndex[5] = (unsigned int)(ii + 1 + Xjj + XYKK1);
-          m.m_inputIndex[6] = (unsigned int)(ii + Xjj1 + XYKK1);
-          m.m_inputIndex[7] = (unsigned int)(ii + 1 + Xjj1 + XYKK1);
-          #ifdef VISP_HAVE_OPENMP
-          #pragma omp critical
-          #endif
-          m_lookupTable2.push_back(m);
+              m_lookupTables[sweepingDirection].push_back(m);
+            }
+          }
         }
       }
     }
+    std::cout << "LUT 1 size (bytes) : " << sizeof(usVoxelWeightAndIndex) * m_lookupTables[0].size() << std::endl;
+    std::cout << "LUT 2 size (bytes) : " << sizeof(usVoxelWeightAndIndex) * m_lookupTables[1].size() << std::endl;
+    break;
   }
-  std::cout << "LUT 1 size (bytes) : " << sizeof(usVoxelWeightAndIndex) * m_lookupTable1.size() << std::endl;
-  std::cout << "LUT 2 size (bytes) : " << sizeof(usVoxelWeightAndIndex) * m_lookupTable2.size() << std::endl;
+  case MULTI_THREAD_FULL_LOOKUP_TABLE:
+  {
+    try
+    {
+        long int LUTmaxSize = (long int)m_nbX*(long int)m_nbY*(long int)m_nbZ;
+        // reserve to avoid reallocation during the LUT filling
+        m_lookupTables[0].reserve(LUTmaxSize);
+        m_lookupTables[1].reserve(LUTmaxSize);
+    }
+    catch(std::exception &e)
+    {
+        throw vpException(vpException::ioError, "usPreScanToPostScan3DConverter::init: using method MULTI_THREAD_FULL_LOOKUP_TABLE leads to %s \n Use another optimization method or downsample the volume", e.what());
+    }
+    for(unsigned int sweepingDirection=0 ; sweepingDirection<2 ; sweepingDirection++) {
+      for (unsigned int x = 0; x < m_nbX; x++) {
+        double xx = m_resolution * x - xmax;
+        for (unsigned int y = 0; y < m_nbY; y++) {
+          double yy = ymin + m_resolution * y;
+#ifdef VISP_HAVE_OPENMP
+#pragma omp parallel for
+#endif
+          for (unsigned int z = 0; z < m_nbZ; z++) {
+            double zz = m_resolution * z - zmax;
+            double i, j, k;
+            usPreScanToPostScan3DConverter::convertPostScanCoordToPreScanCoord(yy, xx, zz, &j, &i, &k, sweepingDirection==0);
+    
+            double ii = floor(i);
+            double jj = floor(j);
+            double kk = floor(k);
+    
+            if (ii >= 0 && jj >= 0 && kk >= 0 && ii + 1 < X && jj + 1 < Y && kk + 1 < Z) {
+              usVoxelWeightAndIndex m;
+              
+              m.m_outputIndex = x + m_nbX * y + nbXY * z;
+    
+              double u = i - ii;
+              double v = j - jj;
+              double w = k - kk;
+              double u1 = 1 - u;
+              double v1 = 1 - v;
+              double w1 = 1 - w;
+    
+              double v1w1 = v1 * w1;
+              double vw1 = v * w1;
+              double v1w = v1 * w;
+              double vw = v * w;
+    
+              m.m_W[0] = u1 * v1w1;
+              m.m_W[1] = u * v1w1;
+              m.m_W[2] = u1 * vw1;
+              m.m_W[3] = u * vw1;
+              m.m_W[4] = u1 * v1w;
+              m.m_W[5] = u * v1w;
+              m.m_W[6] = u1 * vw;
+              m.m_W[7] = u * vw;
+    
+              double Xjj = X * jj;
+              double Xjj1 = X * (jj + 1);
+              double XYKK = XY * kk;
+              double XYKK1 = XY * (kk + 1);
+    
+              m.m_inputIndex[0] = (unsigned int)(ii + Xjj + XYKK);
+              m.m_inputIndex[1] = (unsigned int)(ii + 1 + Xjj + XYKK);
+              m.m_inputIndex[2] = (unsigned int)(ii + Xjj1 + XYKK);
+              m.m_inputIndex[3] = (unsigned int)(ii + 1 + Xjj1 + XYKK);
+              m.m_inputIndex[4] = (unsigned int)(ii + Xjj + XYKK1);
+              m.m_inputIndex[5] = (unsigned int)(ii + 1 + Xjj + XYKK1);
+              m.m_inputIndex[6] = (unsigned int)(ii + Xjj1 + XYKK1);
+              m.m_inputIndex[7] = (unsigned int)(ii + 1 + Xjj1 + XYKK1);
+#ifdef VISP_HAVE_OPENMP
+#pragma omp critical
+#endif
+              m_lookupTables[sweepingDirection].push_back(m);
+            }
+          }
+        }
+      }
+    }
+    std::cout << "LUT 1 size (bytes) : " << sizeof(usVoxelWeightAndIndex) * m_lookupTables[0].size() << std::endl;
+    std::cout << "LUT 2 size (bytes) : " << sizeof(usVoxelWeightAndIndex) * m_lookupTables[1].size() << std::endl;
+    break;
+  }
+  case GPU_FULL_LOOKUP_TABLE:
+  {
+    throw vpException(vpException::notImplementedError, "usPreScanToPostScan3DConverter::init: using method GPU_FULL_LOOKUP_TABLE is not implemented yet");
+    break;
+  }
+  case SINGLE_THREAD_REDUCED_LOOKUP_TABLE:
+  {
+    try
+    {
+        long int LUTmaxSize = (long int)m_nbX*(long int)m_nbY*(long int)m_nbZ;
+        // reserve to avoid reallocation during the LUT filling
+        m_reducedLookupTables[0].reserve(LUTmaxSize);
+        m_reducedLookupTables[1].reserve(LUTmaxSize);
+    }
+    catch(std::exception &e)
+    {
+        throw vpException(vpException::ioError, "usPreScanToPostScan3DConverter::init: using method SINGLE_THREAD_REDUCED_LOOKUP_TABLE leads to %s \n Use another optimization method or downsample the volume", e.what());
+    }
+    for(unsigned int sweepingDirection=0 ; sweepingDirection<2 ; sweepingDirection++) {
+      for (unsigned int x = 0; x < m_nbX; x++) {
+        double xx = m_resolution * x - xmax;
+        for (unsigned int y = 0; y < m_nbY; y++) {
+          double yy = ymin + m_resolution * y;
+          for (unsigned int z = 0; z < m_nbZ; z++) {
+            double zz = m_resolution * z - zmax;
+            double i, j, k;
+            usPreScanToPostScan3DConverter::convertPostScanCoordToPreScanCoord(yy, xx, zz, &j, &i, &k, sweepingDirection==0);
+    
+            double ii = floor(i);
+            double jj = floor(j);
+            double kk = floor(k);
+    
+            if (ii >= 0 && jj >= 0 && kk >= 0 && ii + 1 < X && jj + 1 < Y && kk + 1 < Z) {
+              usVoxelWeightAndIndexReducedMemory m;
+              
+              m.m_outputIndex = x + m_nbX * y + nbXY * z;
+    
+              m.m_W[0] = i - ii;
+              m.m_W[1] = j - jj;
+              m.m_W[2] = k - kk;
+
+              m.m_inputIndex = (unsigned int)(ii + X * jj + XY * kk);
+
+              m_reducedLookupTables[sweepingDirection].push_back(m);
+            }
+          }
+        }
+      }
+    }
+    std::cout << "LUT 1 size (bytes) : " << sizeof(usVoxelWeightAndIndexReducedMemory) * m_reducedLookupTables[0].size() << std::endl;
+    std::cout << "LUT 2 size (bytes) : " << sizeof(usVoxelWeightAndIndexReducedMemory) * m_reducedLookupTables[1].size() << std::endl;
+    break;
+  }
+  case MULTI_THREAD_REDUCED_LOOKUP_TABLE:
+  {
+    try
+    {
+        long int LUTmaxSize = (long int)m_nbX*(long int)m_nbY*(long int)m_nbZ;
+        // reserve to avoid reallocation during the LUT filling
+        m_reducedLookupTables[0].reserve(LUTmaxSize);
+        m_reducedLookupTables[1].reserve(LUTmaxSize);
+    }
+    catch(std::exception &e)
+    {
+        throw vpException(vpException::ioError, "usPreScanToPostScan3DConverter::init: using method MULTI_THREAD_REDUCED_LOOKUP_TABLE leads to %s \n Use another optimization method or downsample the volume", e.what());
+    }
+    for(unsigned int sweepingDirection=0 ; sweepingDirection<2 ; sweepingDirection++) {
+      for (unsigned int x = 0; x < m_nbX; x++) {
+        double xx = m_resolution * x - xmax;
+        for (unsigned int y = 0; y < m_nbY; y++) {
+          double yy = ymin + m_resolution * y;
+#ifdef VISP_HAVE_OPENMP
+#pragma omp parallel for
+#endif
+          for (unsigned int z = 0; z < m_nbZ; z++) {
+            double zz = m_resolution * z - zmax;
+            double i, j, k;
+            usPreScanToPostScan3DConverter::convertPostScanCoordToPreScanCoord(yy, xx, zz, &j, &i, &k, sweepingDirection==0);
+    
+            double ii = floor(i);
+            double jj = floor(j);
+            double kk = floor(k);
+    
+            if (ii >= 0 && jj >= 0 && kk >= 0 && ii + 1 < X && jj + 1 < Y && kk + 1 < Z) {
+              usVoxelWeightAndIndexReducedMemory m;
+              
+              m.m_outputIndex = x + m_nbX * y + nbXY * z;
+    
+              m.m_W[0] = i - ii;
+              m.m_W[1] = j - jj;
+              m.m_W[2] = k - kk;
+
+              m.m_inputIndex = (unsigned int)(ii + X * jj + XY * kk);
+#ifdef VISP_HAVE_OPENMP
+#pragma omp critical
+#endif
+              m_reducedLookupTables[sweepingDirection].push_back(m);
+            }
+          }
+        }
+      }
+    }
+    std::cout << "LUT 1 size (bytes) : " << sizeof(usVoxelWeightAndIndexReducedMemory) * m_reducedLookupTables[0].size() << std::endl;
+    std::cout << "LUT 2 size (bytes) : " << sizeof(usVoxelWeightAndIndexReducedMemory) * m_reducedLookupTables[1].size() << std::endl;
+    break;
+  }
+  case GPU_REDUCED_LOOKUP_TABLE:
+  {
+    throw vpException(vpException::notImplementedError, "usPreScanToPostScan3DConverter::init: using method GPU_REDUCED_LOOKUP_TABLE is not implemented yet");
+    break;
+  }
+  }
+
+  m_conversionOptimizationMethodUsedAtInit = m_converterOptimizationMethod;  
   m_initDone = true;
 }
 
@@ -261,26 +425,301 @@ void usPreScanToPostScan3DConverter::convert(usImagePostScan3D<unsigned char> &p
   unsigned char *dataPost = postScanImage.getData();
   const unsigned char *dataPre = preScanImage.getConstData();
 
-  if (m_SweepInZdirection) {
+  switch(m_converterOptimizationMethod)
+  {
+  case SINGLE_THREAD_DIRECT_CONVERSION:
+  {
+    int X = m_VpreScan.getWidth();
+    int Y = m_VpreScan.getHeight();
+    int Z = m_VpreScan.getNumberOfFrames();
+  
+    double xmax;
+    double ymin;
+    double ymax;
+    double zmax;
+  
+    usPreScanToPostScan3DConverter::convertPreScanCoordToPostScanCoord(0.0, X, Z, &ymin, NULL, NULL);
+    usPreScanToPostScan3DConverter::convertPreScanCoordToPostScanCoord((double)Y, X / 2.0, Z / 2.0, &ymax, NULL, NULL);
+    usPreScanToPostScan3DConverter::convertPreScanCoordToPostScanCoord((double)Y, (double)X, Z / 2.0, NULL, &xmax, NULL);
+    usPreScanToPostScan3DConverter::convertPreScanCoordToPostScanCoord((double)Y, X / 2.0, Z, NULL, NULL, &zmax);
+  
+    unsigned int nbXY = m_nbX * m_nbY;
+    unsigned int XY = X * Y;
+    
+    for (unsigned int x = 0; x < m_nbX; x++) {
+      double xx = m_resolution * x - xmax;
+      for (unsigned int y = 0; y < m_nbY; y++) {
+        double yy = ymin + m_resolution * y;
+        for (unsigned int z = 0; z < m_nbZ; z++) {
+          double zz = m_resolution * z - zmax;
+          double i, j, k;
+          usPreScanToPostScan3DConverter::convertPostScanCoordToPreScanCoord(yy, xx, zz, &j, &i, &k, m_SweepInZdirection);
+  
+          double ii = floor(i);
+          double jj = floor(j);
+          double kk = floor(k);
+  
+          if (ii >= 0 && jj >= 0 && kk >= 0 && ii + 1 < X && jj + 1 < Y && kk + 1 < Z) {
+              
+            double u = i - ii;
+            double v = j - jj;
+            double w = k - kk;
+            double u1 = 1 - u;
+            double v1 = 1 - v;
+            double w1 = 1 - w;
+  
+            double v1w1 = v1 * w1;
+            double vw1 = v * w1;
+            double v1w = v1 * w;
+            double vw = v * w;
+  
+            double W[8] = { u1 * v1w1,
+                            u * v1w1,
+                            u1 * vw1,
+                            u * vw1,
+                            u1 * v1w,
+                            u * v1w,
+                            u1 * vw,
+                            u * vw };
+            
+            double Xjj = X * jj;
+            double Xjj1 = X * (jj + 1);
+            double XYKK = XY * kk;
+            double XYKK1 = XY * (kk + 1);
+            
+            unsigned int index[8] = { (unsigned int)(ii + Xjj + XYKK),
+                                      (unsigned int)(ii + 1 + Xjj + XYKK),
+                                      (unsigned int)(ii + Xjj1 + XYKK),
+                                      (unsigned int)(ii + 1 + Xjj1 + XYKK),
+                                      (unsigned int)(ii + Xjj + XYKK1),
+                                      (unsigned int)(ii + 1 + Xjj + XYKK1),
+                                      (unsigned int)(ii + Xjj1 + XYKK1),
+                                      (unsigned int)(ii + 1 + Xjj1 + XYKK1)};
+            
+            double val = 0;
+            for (int j = 0; j < 8; j++) val += W[j] * dataPre[index[j]];
+            dataPost[x + m_nbX * y + nbXY * z] = (unsigned char)val;
+          }
+        }
+      }
+    }
+    break;
+  }
+  case MULTI_THREAD_DIRECT_CONVERSION:
+  {
+    int X = m_VpreScan.getWidth();
+    int Y = m_VpreScan.getHeight();
+    int Z = m_VpreScan.getNumberOfFrames();
+  
+    double xmax;
+    double ymin;
+    double ymax;
+    double zmax;
+  
+    usPreScanToPostScan3DConverter::convertPreScanCoordToPostScanCoord(0.0, X, Z, &ymin, NULL, NULL);
+    usPreScanToPostScan3DConverter::convertPreScanCoordToPostScanCoord((double)Y, X / 2.0, Z / 2.0, &ymax, NULL, NULL);
+    usPreScanToPostScan3DConverter::convertPreScanCoordToPostScanCoord((double)Y, (double)X, Z / 2.0, NULL, &xmax, NULL);
+    usPreScanToPostScan3DConverter::convertPreScanCoordToPostScanCoord((double)Y, X / 2.0, Z, NULL, NULL, &zmax);
+  
+    unsigned int nbXY = m_nbX * m_nbY;
+    unsigned int XY = X * Y;
+    
+    for (unsigned int x = 0; x < m_nbX; x++) {
+      double xx = m_resolution * x - xmax;
+      for (unsigned int y = 0; y < m_nbY; y++) {
+        double yy = ymin + m_resolution * y;
 #ifdef VISP_HAVE_OPENMP
 #pragma omp parallel for
 #endif
-    for (int i = (int)m_lookupTable1.size() - 1; i >= 0; i--) {
+        for (unsigned int z = 0; z < m_nbZ; z++) {
+          double zz = m_resolution * z - zmax;
+          double i, j, k;
+          usPreScanToPostScan3DConverter::convertPostScanCoordToPreScanCoord(yy, xx, zz, &j, &i, &k, m_SweepInZdirection);
+  
+          double ii = floor(i);
+          double jj = floor(j);
+          double kk = floor(k);
+  
+          if (ii >= 0 && jj >= 0 && kk >= 0 && ii + 1 < X && jj + 1 < Y && kk + 1 < Z) {
+              
+            double u = i - ii;
+            double v = j - jj;
+            double w = k - kk;
+            double u1 = 1 - u;
+            double v1 = 1 - v;
+            double w1 = 1 - w;
+  
+            double v1w1 = v1 * w1;
+            double vw1 = v * w1;
+            double v1w = v1 * w;
+            double vw = v * w;
+  
+            double W[8] = { u1 * v1w1,
+                            u * v1w1,
+                            u1 * vw1,
+                            u * vw1,
+                            u1 * v1w,
+                            u * v1w,
+                            u1 * vw,
+                            u * vw };
+            
+            double Xjj = X * jj;
+            double Xjj1 = X * (jj + 1);
+            double XYKK = XY * kk;
+            double XYKK1 = XY * (kk + 1);
+            
+            unsigned int index[8] = { (unsigned int)(ii + Xjj + XYKK),
+                                      (unsigned int)(ii + 1 + Xjj + XYKK),
+                                      (unsigned int)(ii + Xjj1 + XYKK),
+                                      (unsigned int)(ii + 1 + Xjj1 + XYKK),
+                                      (unsigned int)(ii + Xjj + XYKK1),
+                                      (unsigned int)(ii + 1 + Xjj + XYKK1),
+                                      (unsigned int)(ii + Xjj1 + XYKK1),
+                                      (unsigned int)(ii + 1 + Xjj1 + XYKK1)};
+            
+            double val = 0;
+            for (int j = 0; j < 8; j++) val += W[j] * dataPre[index[j]];
+#ifdef VISP_HAVE_OPENMP
+#pragma omp critical
+#endif
+            dataPost[x + m_nbX * y + nbXY * z] = (unsigned char)val;
+          }
+        }
+      }
+    }
+    break;
+  }
+  case GPU_DIRECT_CONVERSION:
+  {
+    throw vpException(vpException::notImplementedError, "usPreScanToPostScan3DConverter::convert: using method GPU_DIRECT_CONVERSION is not implemented yet");
+    break;
+  }
+  case SINGLE_THREAD_FULL_LOOKUP_TABLE:
+  {
+    const unsigned int d = m_SweepInZdirection?0:1;
+    for (int i = (int)m_lookupTables[d].size() - 1; i >= 0; i--) {
       double v = 0;
       for (int j = 0; j < 8; j++)
-        v += m_lookupTable1[i].m_W[j] * dataPre[m_lookupTable1[i].m_inputIndex[j]];
-      dataPost[m_lookupTable1[i].m_outputIndex] = (unsigned char)v;
+        v += m_lookupTables[d][i].m_W[j] * dataPre[m_lookupTables[d][i].m_inputIndex[j]];
+      dataPost[m_lookupTables[d][i].m_outputIndex] = (unsigned char)v;
     }
-  } else {
+    break;
+  }
+  case MULTI_THREAD_FULL_LOOKUP_TABLE:
+  {
+    const unsigned int d = m_SweepInZdirection?0:1;
 #ifdef VISP_HAVE_OPENMP
 #pragma omp parallel for
 #endif
-    for (int i = (int)m_lookupTable2.size() - 1; i >= 0; i--) {
+    for (int i = (int)m_lookupTables[d].size() - 1; i >= 0; i--) {
       double v = 0;
       for (int j = 0; j < 8; j++)
-        v += m_lookupTable2[i].m_W[j] * dataPre[m_lookupTable2[i].m_inputIndex[j]];
-      dataPost[m_lookupTable2[i].m_outputIndex] = (unsigned char)v;
+        v += m_lookupTables[d][i].m_W[j] * dataPre[m_lookupTables[d][i].m_inputIndex[j]];
+      dataPost[m_lookupTables[d][i].m_outputIndex] = (unsigned char)v;
     }
+    break;
+  }
+  case GPU_FULL_LOOKUP_TABLE:
+  {
+    throw vpException(vpException::notImplementedError, "usPreScanToPostScan3DConverter::convert: using method GPU_FULL_LOOKUP_TABLE is not implemented yet");
+    break;
+  }
+  case SINGLE_THREAD_REDUCED_LOOKUP_TABLE:
+  {
+    const unsigned int d = m_SweepInZdirection?0:1;
+    unsigned int X = m_VpreScan.getWidth();
+    unsigned int Y = m_VpreScan.getHeight();
+    unsigned int XY = X * Y;
+    for (int i = (int)m_reducedLookupTables[d].size() - 1; i >= 0; i--) {     
+      const usVoxelWeightAndIndexReducedMemory &m = m_reducedLookupTables[d][i];
+      double u = m.m_W[0];
+      double v = m.m_W[1];
+      double w = m.m_W[2];
+      double u1 = 1 - u;
+      double v1 = 1 - v;
+      double w1 = 1 - w;
+
+      double v1w1 = v1 * w1;
+      double vw1 = v * w1;
+      double v1w = v1 * w;
+      double vw = v * w;
+
+      double W[8] = { u1 * v1w1,
+                      u * v1w1,
+                      u1 * vw1,
+                      u * vw1,
+                      u1 * v1w,
+                      u * v1w,
+                      u1 * vw,
+                      u * vw };
+      
+      unsigned int index[8] = { m.m_inputIndex,
+                                m.m_inputIndex + 1,
+                                m.m_inputIndex +     X,
+                                m.m_inputIndex + 1 + X,
+                                m.m_inputIndex +         XY,
+                                m.m_inputIndex + 1     + XY,
+                                m.m_inputIndex +     X + XY,
+                                m.m_inputIndex + 1 + X + XY };
+
+      double val = 0;
+      for (int j = 0; j < 8; j++) val += W[j] * dataPre[index[j]];
+      dataPost[m_reducedLookupTables[d][i].m_outputIndex] = (unsigned char)val;
+    }
+    break;
+  }
+  case MULTI_THREAD_REDUCED_LOOKUP_TABLE:
+  {
+    const unsigned int d = m_SweepInZdirection?0:1;
+    unsigned int X = m_VpreScan.getWidth();
+    unsigned int Y = m_VpreScan.getHeight();
+    unsigned int XY = X * Y;
+#ifdef VISP_HAVE_OPENMP
+#pragma omp parallel for
+#endif
+    for (int i = (int)m_reducedLookupTables[d].size() - 1; i >= 0; i--) {    
+      const usVoxelWeightAndIndexReducedMemory &m = m_reducedLookupTables[d][i];
+      double u = m.m_W[0];
+      double v = m.m_W[1];
+      double w = m.m_W[2];
+      double u1 = 1 - u;
+      double v1 = 1 - v;
+      double w1 = 1 - w;
+
+      double v1w1 = v1 * w1;
+      double vw1 = v * w1;
+      double v1w = v1 * w;
+      double vw = v * w;
+
+      double W[8] = { u1 * v1w1,
+                      u * v1w1,
+                      u1 * vw1,
+                      u * vw1,
+                      u1 * v1w,
+                      u * v1w,
+                      u1 * vw,
+                      u * vw };
+      
+      unsigned int index[8] = { m.m_inputIndex,
+                                m.m_inputIndex + 1,
+                                m.m_inputIndex +     X,
+                                m.m_inputIndex + 1 + X,
+                                m.m_inputIndex +         XY,
+                                m.m_inputIndex + 1     + XY,
+                                m.m_inputIndex +     X + XY,
+                                m.m_inputIndex + 1 + X + XY };
+
+      double val = 0;
+      for (int j = 0; j < 8; j++) val += W[j] * dataPre[index[j]];
+      dataPost[m_reducedLookupTables[d][i].m_outputIndex] = (unsigned char)val;
+    }
+    break;
+  }
+  case GPU_REDUCED_LOOKUP_TABLE:
+  {
+    throw vpException(vpException::notImplementedError, "usPreScanToPostScan3DConverter::convert: using method GPU_REDUCED_LOOKUP_TABLE is not implemented yet");
+    break;
+  }
   }
 
   // writing post-scan image settings
@@ -290,6 +729,49 @@ void usPreScanToPostScan3DConverter::convert(usImagePostScan3D<unsigned char> &p
   postScanImage.setElementSpacingY(m_resolution);
   postScanImage.setElementSpacingZ(m_resolution);
   postScanImage.setScanLineDepth(m_resolution * m_VpreScan.getBModeSampleNumber());
+}
+
+/**
+ * Choose the method used for the optimization of the conversion.
+ * @param method optimization method.
+ */
+void usPreScanToPostScan3DConverter::setConverterOptimizationMethod(usConverterOptimizationMethod method)
+{
+  m_converterOptimizationMethod = method;
+
+  switch(m_converterOptimizationMethod)
+  {
+  case SINGLE_THREAD_DIRECT_CONVERSION:
+  case SINGLE_THREAD_FULL_LOOKUP_TABLE:
+  case SINGLE_THREAD_REDUCED_LOOKUP_TABLE:
+  {
+    break;
+  }
+  case MULTI_THREAD_DIRECT_CONVERSION:
+  case MULTI_THREAD_FULL_LOOKUP_TABLE:
+  case MULTI_THREAD_REDUCED_LOOKUP_TABLE:
+  {
+#ifndef VISP_HAVE_OPENMP
+    std::cout << "Warning in usPreScanToPostScan3DConverter::setConverterOptimizationMethod: OpenMP is not available to use multi-thread optimization, will use single thread implementation instead." << std::endl;
+#endif
+    break;
+  }
+  case GPU_DIRECT_CONVERSION:
+  {
+    throw vpException(vpException::notImplementedError, "usPreScanToPostScan3DConverter::setConverterOptimizationMethod: using method GPU_DIRECT_CONVERSION is not implemented yet");
+    break;
+  }
+  case GPU_FULL_LOOKUP_TABLE:
+  {
+    throw vpException(vpException::notImplementedError, "usPreScanToPostScan3DConverter::setConverterOptimizationMethod: using method GPU_FULL_LOOKUP_TABLE is not implemented yet");
+    break;
+  }
+  case GPU_REDUCED_LOOKUP_TABLE:
+  {
+    throw vpException(vpException::notImplementedError, "usPreScanToPostScan3DConverter::setConverterOptimizationMethod: using method GPU_REDUCED_LOOKUP_TABLE is not implemented yet");
+    break;
+  }
+  }
 }
 
 /**

--- a/modules/ustk_grabber/include/visp3/ustk_grabber/usNetworkGrabber.h
+++ b/modules/ustk_grabber/include/visp3/ustk_grabber/usNetworkGrabber.h
@@ -220,6 +220,9 @@ protected:
   // grabber state
   bool m_isInit;
   bool m_isRunning;
+
+  // separated thread to run the event loop
+  QThread *m_thread;
 };
 
 #endif // QT4 || QT5

--- a/modules/ustk_grabber/include/visp3/ustk_grabber/usNetworkGrabberPostScan2D.h
+++ b/modules/ustk_grabber/include/visp3/ustk_grabber/usNetworkGrabberPostScan2D.h
@@ -92,9 +92,6 @@ private:
   std::vector<usFrameGrabbedInfo<usImagePostScan2D<unsigned char> > *> m_outputBuffer;
   bool m_firstFrameAvailable;
 
-  // to manage ptrs switch init
-  bool m_swichOutputInit;
-
   // to manage the recording process
   bool m_recordingOn;
   std::string m_recordingPath;

--- a/modules/ustk_grabber/include/visp3/ustk_grabber/usNetworkGrabberPostScanBiPlan.h
+++ b/modules/ustk_grabber/include/visp3/ustk_grabber/usNetworkGrabberPostScanBiPlan.h
@@ -88,8 +88,6 @@ private:
 
   bool m_firstFrameAvailable;
 
-  // to manage ptrs switch init
-  bool m_swichOutputInit;
 };
 
 #endif // QT4 || QT5

--- a/modules/ustk_grabber/include/visp3/ustk_grabber/usNetworkGrabberPreScan2D.h
+++ b/modules/ustk_grabber/include/visp3/ustk_grabber/usNetworkGrabberPreScan2D.h
@@ -98,9 +98,6 @@ private:
   std::vector<usFrameGrabbedInfo<usImagePreScan2D<unsigned char> > *> m_outputBuffer;
   bool m_firstFrameAvailable;
 
-  // to manage ptrs switch init
-  bool m_swichOutputInit;
-
   // to manage the recording process
   bool m_recordingOn;
   usMHDSequenceWriter m_sequenceWriter;

--- a/modules/ustk_grabber/include/visp3/ustk_grabber/usNetworkGrabberPreScan3D.h
+++ b/modules/ustk_grabber/include/visp3/ustk_grabber/usNetworkGrabberPreScan3D.h
@@ -106,9 +106,6 @@ private:
   bool m_firstFrameAvailable;
   bool m_firstVolumeAvailable;
 
-  // to know motor sweep direction for volume grabbed
-  bool m_motorSweepingInZDirection;
-
   // to manage the recording process
   bool m_recordingOn;
   usMHDSequenceWriter m_sequenceWriter;

--- a/modules/ustk_grabber/include/visp3/ustk_grabber/usNetworkGrabberPreScan3D.h
+++ b/modules/ustk_grabber/include/visp3/ustk_grabber/usNetworkGrabberPreScan3D.h
@@ -106,9 +106,6 @@ private:
   bool m_firstFrameAvailable;
   bool m_firstVolumeAvailable;
 
-  // to manage ptrs switch init
-  bool m_swichOutputInit;
-
   // to know motor sweep direction for volume grabbed
   bool m_motorSweepingInZDirection;
 

--- a/modules/ustk_grabber/include/visp3/ustk_grabber/usNetworkGrabberRF2D.h
+++ b/modules/ustk_grabber/include/visp3/ustk_grabber/usNetworkGrabberRF2D.h
@@ -90,9 +90,6 @@ private:
   std::vector<usFrameGrabbedInfo<usImageRF2D<short int> > *> m_outputBuffer;
   bool m_firstFrameAvailable;
 
-  // to manage ptrs switch init
-  bool m_swichOutputInit;
-
   // to manage the recording process
   bool m_recordingOn;
   usMHDSequenceWriter m_sequenceWriter;

--- a/modules/ustk_grabber/include/visp3/ustk_grabber/usNetworkGrabberRF3D.h
+++ b/modules/ustk_grabber/include/visp3/ustk_grabber/usNetworkGrabberRF3D.h
@@ -105,9 +105,6 @@ private:
   bool m_firstFrameAvailable;
   bool m_firstVolumeAvailable;
 
-  // to know motor sweep direction for volume grabbed
-  bool m_motorSweepingInZDirection;
-
   // to manage the recording process
   bool m_recordingOn;
   usMHDSequenceWriter m_sequenceWriter;

--- a/modules/ustk_grabber/include/visp3/ustk_grabber/usNetworkGrabberRF3D.h
+++ b/modules/ustk_grabber/include/visp3/ustk_grabber/usNetworkGrabberRF3D.h
@@ -105,9 +105,6 @@ private:
   bool m_firstFrameAvailable;
   bool m_firstVolumeAvailable;
 
-  // to manage ptrs switch init
-  bool m_swichOutputInit;
-
   // to know motor sweep direction for volume grabbed
   bool m_motorSweepingInZDirection;
 

--- a/modules/ustk_grabber/src/usNetworkGrabber.cpp
+++ b/modules/ustk_grabber/src/usNetworkGrabber.cpp
@@ -79,6 +79,13 @@ usNetworkGrabber::usNetworkGrabber(QObject *parent) : QObject(parent)
 */
 usNetworkGrabber::~usNetworkGrabber()
 {
+  this->stopAcquisition();
+  if(m_thread) {
+    m_thread->quit();
+    m_thread->wait();
+    delete m_thread;
+    m_thread = NULL;
+  }
   if (m_tcpSocket->isOpen())
     m_tcpSocket->close();
 }

--- a/modules/ustk_grabber/src/usNetworkGrabber.cpp
+++ b/modules/ustk_grabber/src/usNetworkGrabber.cpp
@@ -66,6 +66,8 @@ usNetworkGrabber::usNetworkGrabber(QObject *parent) : QObject(parent)
 
   m_isInit = false;
   m_isRunning = false;
+  
+  m_thread = NULL;
 
   QObject::connect(this, SIGNAL(serverUpdateEnded(bool)), this, SLOT(serverUpdated(bool)));
   QObject::connect(this, SIGNAL(runAcquisitionSignal(bool)), this, SLOT(sendRunSignal(bool)));
@@ -637,12 +639,18 @@ void usNetworkGrabber::setTransmitFrequency(int transmitFrequency)
 }
 
 /**
-* Sends the command to run the acquisition on the ulstrasound station.
+* Sends the command to run the acquisition on the ultrasound station and start a new thread to run the data reception
 */
 void usNetworkGrabber::runAcquisition()
 {
+  if (m_thread == NULL) {
+    m_thread = new QThread;
+    this->moveToThread(m_thread);
+    m_thread->start();
+  }
   emit runAcquisitionSignal(true);
-  vpTime::wait(10); // workaround to allow calling run / stop methods one just after another
+
+  //vpTime::wait(10); // workaround to allow calling run / stop methods one just after another
 }
 
 /**
@@ -654,6 +662,7 @@ void usNetworkGrabber::runAcquisition()
 void usNetworkGrabber::stopAcquisition()
 {
   emit runAcquisitionSignal(false);
+
   vpTime::wait(10); // workaround to allow calling run / stop methods one just after another
 }
 

--- a/modules/ustk_grabber/src/usNetworkGrabberPreScan2D.cpp
+++ b/modules/ustk_grabber/src/usNetworkGrabberPreScan2D.cpp
@@ -53,8 +53,6 @@ usNetworkGrabberPreScan2D::usNetworkGrabberPreScan2D(usNetworkGrabber *parent) :
 
   m_firstFrameAvailable = false;
 
-  m_swichOutputInit = false;
-
   m_recordingOn = false;
   m_firstImageTimestamp = 0;
 
@@ -257,36 +255,21 @@ void usNetworkGrabberPreScan2D::invertRowsCols()
 */
 usFrameGrabbedInfo<usImagePreScan2D<unsigned char> > *usNetworkGrabberPreScan2D::acquire()
 {
-  // check if the first frame is arrived
-  if (!m_firstFrameAvailable) {
-    throw(vpException(vpException::fatalError, "first frame not yet grabbed, cannot acquire"));
-  }
-
-  // user grabs too fast
-  if (m_outputBuffer.at(OUTPUT_FRAME_POSITION_IN_VEC)->getFrameCount() ==
-      m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getFrameCount() + 1) {
+  // manage first frame or if user grabs too fast
+  if (!m_firstFrameAvailable ||
+      m_outputBuffer.at(OUTPUT_FRAME_POSITION_IN_VEC)->getFrameCount() >=
+        m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getFrameCount()) {
     // we wait until a new frame is available
     QEventLoop loop;
     loop.connect(this, SIGNAL(newFrameAvailable()), SLOT(quit()));
     loop.exec();
-
-    // switch pointers
-    usFrameGrabbedInfo<usImagePreScan2D<unsigned char> > *savePtr = m_outputBuffer.at(OUTPUT_FRAME_POSITION_IN_VEC);
-    m_outputBuffer.at(OUTPUT_FRAME_POSITION_IN_VEC) = m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC);
-    m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC) = savePtr;
-    m_swichOutputInit = true;
   }
 
-  // if more recent frame available
-  else if (m_outputBuffer.at(OUTPUT_FRAME_POSITION_IN_VEC)->getFrameCount() <
-               m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getFrameCount() ||
-           !m_swichOutputInit) {
-    // switch pointers (output <-> mostRecentFilled)
-    usFrameGrabbedInfo<usImagePreScan2D<unsigned char> > *savePtr = m_outputBuffer.at(OUTPUT_FRAME_POSITION_IN_VEC);
-    m_outputBuffer.at(OUTPUT_FRAME_POSITION_IN_VEC) = m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC);
-    m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC) = savePtr;
-    m_swichOutputInit = true;
-  }
+  // switch pointers
+  usFrameGrabbedInfo<usImagePreScan2D<unsigned char> > *savePtr = m_outputBuffer.at(OUTPUT_FRAME_POSITION_IN_VEC);
+  m_outputBuffer.at(OUTPUT_FRAME_POSITION_IN_VEC) = m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC);
+  m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC) = savePtr;
+
   return m_outputBuffer.at(OUTPUT_FRAME_POSITION_IN_VEC);
 }
 

--- a/modules/ustk_grabber/src/usNetworkGrabberPreScan3D.cpp
+++ b/modules/ustk_grabber/src/usNetworkGrabberPreScan3D.cpp
@@ -278,7 +278,7 @@ void usNetworkGrabberPreScan3D::includeFrameInVolume()
 
   for (unsigned int i = 0; i < m_grabbedImage.getHeight(); i++)
     for (unsigned int j = 0; j < m_grabbedImage.getWidth(); j++) {
-      (*m_outputBuffer.at(CURRENT_FILLED_FRAME_POSITION_IN_VEC))(i, j, framePostition, m_grabbedImage(i, j));
+      (*m_outputBuffer.at(CURRENT_FILLED_FRAME_POSITION_IN_VEC))(j, i, framePostition, m_grabbedImage(i, j));
     }
 
   // we reach the end of a volume

--- a/modules/ustk_grabber/src/usNetworkGrabberPreScan3D.cpp
+++ b/modules/ustk_grabber/src/usNetworkGrabberPreScan3D.cpp
@@ -53,7 +53,7 @@ usNetworkGrabberPreScan3D::usNetworkGrabberPreScan3D(usNetworkGrabber *parent)
   m_firstFrameAvailable = false;
   m_firstVolumeAvailable = false;
 
-  m_motorSweepingInZDirection = true;
+  m_motorSweepingInZDirection = false;
 
   m_recordingOn = false;
   m_firstImageTimestamp = 0;
@@ -269,7 +269,7 @@ void usNetworkGrabberPreScan3D::includeFrameInVolume()
   int framePosition = (m_grabbedImage.getFrameCount() % m_grabbedImage.getFramesPerVolume()); // from 0 to FPV-1
 
   // setting timestamps
-  if (volumeIndex % 2 != 0) // case of backward moving motor (opposite to Z direction)
+  if (volumeIndex % 2 == 0) // case of backward moving motor (opposite to Z direction)
     framePosition = m_grabbedImage.getFramesPerVolume() - framePosition - 1; // inverting frames order
 
   m_outputBuffer.at(CURRENT_FILLED_FRAME_POSITION_IN_VEC)->addTimeStamp(m_grabbedImage.getTimeStamp(), framePosition);
@@ -298,7 +298,7 @@ void usNetworkGrabberPreScan3D::includeFrameInVolume()
                                     m_firstImageTimestamp);
       m_sequenceWriter.write(*m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC), timestampsToWrite);
     }
-    if (volumeIndex % 2 != 0) // case of backward moving motor (opposite to Z direction)
+    if (volumeIndex % 2 == 0) // case of backward moving motor (opposite to Z direction)
       m_motorSweepingInZDirection = true;
     else
       m_motorSweepingInZDirection = false;

--- a/modules/ustk_grabber/src/usNetworkGrabberPreScan3D.cpp
+++ b/modules/ustk_grabber/src/usNetworkGrabberPreScan3D.cpp
@@ -53,7 +53,6 @@ usNetworkGrabberPreScan3D::usNetworkGrabberPreScan3D(usNetworkGrabber *parent)
   m_firstFrameAvailable = false;
   m_firstVolumeAvailable = false;
 
-  m_swichOutputInit = false;
   m_motorSweepingInZDirection = true;
 
   m_recordingOn = false;
@@ -267,24 +266,24 @@ void usNetworkGrabberPreScan3D::includeFrameInVolume()
 
   // Inserting frame in volume by inverting rows and cols voxels (along x and y axis), to match ustk volume storage
   int volumeIndex = (m_grabbedImage.getFrameCount() / m_grabbedImage.getFramesPerVolume());    // from 0
-  int framePostition = (m_grabbedImage.getFrameCount() % m_grabbedImage.getFramesPerVolume()); // from 0 to FPV-1
+  int framePosition = (m_grabbedImage.getFrameCount() % m_grabbedImage.getFramesPerVolume()); // from 0 to FPV-1
 
   // setting timestamps
   if (volumeIndex % 2 != 0) // case of backward moving motor (opposite to Z direction)
-    framePostition = m_grabbedImage.getFramesPerVolume() - framePostition - 1; // inverting frames order
+    framePosition = m_grabbedImage.getFramesPerVolume() - framePosition - 1; // inverting frames order
 
-  m_outputBuffer.at(CURRENT_FILLED_FRAME_POSITION_IN_VEC)->addTimeStamp(m_grabbedImage.getTimeStamp(), framePostition);
+  m_outputBuffer.at(CURRENT_FILLED_FRAME_POSITION_IN_VEC)->addTimeStamp(m_grabbedImage.getTimeStamp(), framePosition);
   m_outputBuffer.at(CURRENT_FILLED_FRAME_POSITION_IN_VEC)->setVolumeCount(volumeIndex);
 
   for (unsigned int i = 0; i < m_grabbedImage.getHeight(); i++)
     for (unsigned int j = 0; j < m_grabbedImage.getWidth(); j++) {
-      (*m_outputBuffer.at(CURRENT_FILLED_FRAME_POSITION_IN_VEC))(j, i, framePostition, m_grabbedImage(i, j));
+      (*m_outputBuffer.at(CURRENT_FILLED_FRAME_POSITION_IN_VEC))(j, i, framePosition, m_grabbedImage(i, j));
     }
 
   // we reach the end of a volume
   if (m_firstFrameAvailable &&
-      ((framePostition == 0 && !m_motorSweepingInZDirection) ||
-       (framePostition == (int)m_outputBuffer.at(CURRENT_FILLED_FRAME_POSITION_IN_VEC)->getFrameNumber() - 1 &&
+      ((framePosition == 0 && !m_motorSweepingInZDirection) ||
+       (framePosition == (int)m_outputBuffer.at(CURRENT_FILLED_FRAME_POSITION_IN_VEC)->getFrameNumber() - 1 &&
         m_motorSweepingInZDirection))) {
     // Now CURRENT_FILLED_FRAME_POSITION_IN_VEC has become the last frame received
     // So we switch pointers beween MOST_RECENT_FRAME_POSITION_IN_VEC and CURRENT_FILLED_FRAME_POSITION_IN_VEC
@@ -303,6 +302,8 @@ void usNetworkGrabberPreScan3D::includeFrameInVolume()
       m_motorSweepingInZDirection = true;
     else
       m_motorSweepingInZDirection = false;
+    
+    m_firstVolumeAvailable = true;
     emit(newVolumeAvailable());
   }
 
@@ -319,109 +320,41 @@ void usNetworkGrabberPreScan3D::includeFrameInVolume()
 */
 usVolumeGrabbedInfo<usImagePreScan3D<unsigned char> > *usNetworkGrabberPreScan3D::acquire()
 {
-  // manage first volume
-  if (!m_firstVolumeAvailable) {
+  // manage first volume or if user grabs too fast
+  if (!m_firstVolumeAvailable || 
+      m_outputBuffer.at(OUTPUT_FRAME_POSITION_IN_VEC)->getVolumeCount() >=
+          m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getVolumeCount()) {
     // we wait until the first is available
     QEventLoop loop;
     loop.connect(this, SIGNAL(newVolumeAvailable()), SLOT(quit()));
     loop.exec();
+  }
 
-    // check parity
-    bool parityControl = false;
-    if (m_volumeField == ODD) {
-      if (m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getVolumeCount() % 2 == 1) {
-        parityControl = true;
-      }
-    } else if (m_volumeField == EVEN) {
-      if (m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getVolumeCount() % 2 == 0) {
-        parityControl = true;
-      }
-    } else {
+  // check parity
+  bool parityControl = false;
+  if (m_volumeField == ODD) {
+    if (m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getVolumeCount() % 2 == 1) {
       parityControl = true;
     }
-
-    // if parity not ok, we wait next volume
-    if (!parityControl) {
-      QEventLoop loop;
-      loop.connect(this, SIGNAL(newVolumeAvailable()), SLOT(quit()));
-      loop.exec();
+  } else if (m_volumeField == EVEN) {
+    if (m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getVolumeCount() % 2 == 0) {
+      parityControl = true;
     }
-
-    // switch pointers
-    usVolumeGrabbedInfo<usImagePreScan3D<unsigned char> > *savePtr = m_outputBuffer.at(OUTPUT_FRAME_POSITION_IN_VEC);
-    m_outputBuffer.at(OUTPUT_FRAME_POSITION_IN_VEC) = m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC);
-    m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC) = savePtr;
-    m_swichOutputInit = true;
   } else {
-    // user grabs too fast
-    if (m_outputBuffer.at(OUTPUT_FRAME_POSITION_IN_VEC)->getVolumeCount() ==
-        m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getVolumeCount() + 1) {
-      // we wait until a new frame is available
-      QEventLoop loop;
-      loop.connect(this, SIGNAL(newVolumeAvailable()), SLOT(quit()));
-      loop.exec();
-
-      // check parity
-      bool parityControl = false;
-      if (m_volumeField == ODD) {
-        if (m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getVolumeCount() % 2 == 1) {
-          parityControl = true;
-        }
-      } else if (m_volumeField == EVEN) {
-        if (m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getVolumeCount() % 2 == 0) {
-          parityControl = true;
-        }
-      } else {
-        parityControl = true;
-      }
-
-      // if parity not ok, we wait next volume
-      if (!parityControl) {
-        QEventLoop loop;
-        loop.connect(this, SIGNAL(newVolumeAvailable()), SLOT(quit()));
-        loop.exec();
-      }
-
-      // switch pointers
-      usVolumeGrabbedInfo<usImagePreScan3D<unsigned char> > *savePtr = m_outputBuffer.at(OUTPUT_FRAME_POSITION_IN_VEC);
-      m_outputBuffer.at(OUTPUT_FRAME_POSITION_IN_VEC) = m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC);
-      m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC) = savePtr;
-      m_swichOutputInit = true;
-    }
-
-    // if more recent frame available
-    else if (m_outputBuffer.at(OUTPUT_FRAME_POSITION_IN_VEC)->getVolumeCount() <
-                 m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getVolumeCount() ||
-             !m_swichOutputInit) {
-
-      // check parity
-      bool parityControl = false;
-      if (m_volumeField == ODD) {
-        if (m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getVolumeCount() % 2 == 1) {
-          parityControl = true;
-        }
-      } else if (m_volumeField == EVEN) {
-        if (m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC)->getVolumeCount() % 2 == 0) {
-          parityControl = true;
-        }
-      } else {
-        parityControl = true;
-      }
-
-      // if parity not ok, we wait next volume
-      if (!parityControl) {
-        QEventLoop loop;
-        loop.connect(this, SIGNAL(newVolumeAvailable()), SLOT(quit()));
-        loop.exec();
-      }
-
-      // switch pointers (output <-> mostRecentFilled)
-      usVolumeGrabbedInfo<usImagePreScan3D<unsigned char> > *savePtr = m_outputBuffer.at(OUTPUT_FRAME_POSITION_IN_VEC);
-      m_outputBuffer.at(OUTPUT_FRAME_POSITION_IN_VEC) = m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC);
-      m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC) = savePtr;
-      m_swichOutputInit = true;
-    }
+    parityControl = true;
   }
+  
+  // if parity not ok, we wait next volume
+  if (!parityControl) {
+    QEventLoop loop;
+    loop.connect(this, SIGNAL(newVolumeAvailable()), SLOT(quit()));
+    loop.exec();
+  }
+  
+  // switch pointers
+  usVolumeGrabbedInfo<usImagePreScan3D<unsigned char> > *savePtr = m_outputBuffer.at(OUTPUT_FRAME_POSITION_IN_VEC);
+  m_outputBuffer.at(OUTPUT_FRAME_POSITION_IN_VEC) = m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC);
+  m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC) = savePtr;
 
   return m_outputBuffer.at(OUTPUT_FRAME_POSITION_IN_VEC);
 }

--- a/modules/ustk_grabber/src/usNetworkGrabberRF3D.cpp
+++ b/modules/ustk_grabber/src/usNetworkGrabberRF3D.cpp
@@ -52,7 +52,7 @@ usNetworkGrabberRF3D::usNetworkGrabberRF3D(usNetworkGrabber *parent) : usNetwork
   m_firstFrameAvailable = false;
   m_firstVolumeAvailable = false;
 
-  m_motorSweepingInZDirection = true;
+  m_motorSweepingInZDirection = false;
 
   m_recordingOn = false;
   m_firstImageTimestamp = 0;
@@ -271,7 +271,7 @@ void usNetworkGrabberRF3D::includeFrameInVolume()
   int framePosition = m_grabbedImage.getFrameCount() % m_grabbedImage.getFramesPerVolume(); // from 0 to FPV-1
 
   // setting timestamps
-  if (volumeIndex % 2 != 0) // case of backward moving motor (opposite to Z direction)
+  if (volumeIndex % 2 == 0) // case of backward moving motor (opposite to Z direction)
     framePosition = m_grabbedImage.getFramesPerVolume() - framePosition - 1;
 
   m_outputBuffer.at(CURRENT_FILLED_FRAME_POSITION_IN_VEC)->addTimeStamp(m_grabbedImage.getTimeStamp(), framePosition);
@@ -301,7 +301,7 @@ void usNetworkGrabberRF3D::includeFrameInVolume()
                                     m_firstImageTimestamp);
       m_sequenceWriter.write(*m_outputBuffer.at(MOST_RECENT_FRAME_POSITION_IN_VEC), timestampsToWrite);
     }
-    if (volumeIndex % 2 != 0) // case of backward moving motor (opposite to Z direction)
+    if (volumeIndex % 2 == 0) // case of backward moving motor (opposite to Z direction)
       m_motorSweepingInZDirection = true;
     else
       m_motorSweepingInZDirection = false;

--- a/modules/ustk_grabber/src/usNetworkGrabberRF3D.cpp
+++ b/modules/ustk_grabber/src/usNetworkGrabberRF3D.cpp
@@ -264,29 +264,29 @@ void usNetworkGrabberRF3D::includeFrameInVolume()
   m_outputBuffer.at(CURRENT_FILLED_FRAME_POSITION_IN_VEC)->setMotorSettings(m_motorSettings);
 
   m_outputBuffer.at(CURRENT_FILLED_FRAME_POSITION_IN_VEC)
-      ->resize(m_grabbedImage.getWidth(), m_grabbedImage.getHeight(), m_motorSettings.getFrameNumber());
+      ->resize(m_grabbedImage.getHeight(), m_grabbedImage.getWidth(), m_motorSettings.getFrameNumber());
 
   // Inserting frame in volume
   int volumeIndex = m_grabbedImage.getFrameCount() / m_grabbedImage.getFramesPerVolume();    // from 0
-  int framePostition = m_grabbedImage.getFrameCount() % m_grabbedImage.getFramesPerVolume(); // from 0 to FPV-1
+  int framePosition = m_grabbedImage.getFrameCount() % m_grabbedImage.getFramesPerVolume(); // from 0 to FPV-1
 
   // setting timestamps
   if (volumeIndex % 2 != 0) // case of backward moving motor (opposite to Z direction)
-    framePostition = m_grabbedImage.getFramesPerVolume() - framePostition - 1;
+    framePosition = m_grabbedImage.getFramesPerVolume() - framePosition - 1;
 
-  m_outputBuffer.at(CURRENT_FILLED_FRAME_POSITION_IN_VEC)->addTimeStamp(m_grabbedImage.getTimeStamp(), framePostition);
+  m_outputBuffer.at(CURRENT_FILLED_FRAME_POSITION_IN_VEC)->addTimeStamp(m_grabbedImage.getTimeStamp(), framePosition);
   m_outputBuffer.at(CURRENT_FILLED_FRAME_POSITION_IN_VEC)->setVolumeCount(volumeIndex);
 
   for (unsigned int i = 0; i < m_grabbedImage.getHeight(); i++) {
     for (unsigned int j = 0; j < m_grabbedImage.getWidth(); j++) {
-      (*m_outputBuffer.at(CURRENT_FILLED_FRAME_POSITION_IN_VEC))(i, j, framePostition, m_grabbedImage(i, j));
+      (*m_outputBuffer.at(CURRENT_FILLED_FRAME_POSITION_IN_VEC))(i, j, framePosition, m_grabbedImage(i, j));
     }
   }
 
   // we reach the end of a volume
   if (m_firstFrameAvailable &&
-      ((framePostition == 0 && !m_motorSweepingInZDirection) ||
-       (framePostition == (int)m_outputBuffer.at(CURRENT_FILLED_FRAME_POSITION_IN_VEC)->getFrameNumber() - 1 &&
+      ((framePosition == 0 && !m_motorSweepingInZDirection) ||
+       (framePosition == (int)m_outputBuffer.at(CURRENT_FILLED_FRAME_POSITION_IN_VEC)->getFrameNumber() - 1 &&
         m_motorSweepingInZDirection))) {
     // Now CURRENT_FILLED_FRAME_POSITION_IN_VEC has become the last frame received
     // So we switch pointers beween MOST_RECENT_FRAME_POSITION_IN_VEC and CURRENT_FILLED_FRAME_POSITION_IN_VEC

--- a/tutorial/ustk/elastography/tutorial-elastography-2D-separate-displays.cpp
+++ b/tutorial/ustk/elastography/tutorial-elastography-2D-separate-displays.cpp
@@ -25,8 +25,6 @@ int main(int argc, char **argv)
   usElastography *elastography = new usElastography;
   elastography->setROI(40, 3200, 50, 500);
 
-  QThread *grabbingThread = new QThread();
-
   usNetworkGrabberRF2D *qtGrabber = new usNetworkGrabberRF2D();
   qtGrabber->setIPAddress("127.0.0.1");
   qtGrabber->connectToServer();
@@ -61,10 +59,6 @@ int main(int argc, char **argv)
   qtGrabber->initAcquisition(header);
 
   qtGrabber->runAcquisition();
-
-  // Move the grabber object to another thread
-  qtGrabber->moveToThread(grabbingThread);
-  grabbingThread->start();
 
   std::cout << "waiting ultrasound initialisation..." << std::endl;
 

--- a/tutorial/ustk/elastography/tutorial-elastography-2D.cpp
+++ b/tutorial/ustk/elastography/tutorial-elastography-2D.cpp
@@ -33,8 +33,6 @@ int main(int argc, char **argv)
   usElastography *elastography = new usElastography;
   elastography->setROI(40, 2700, 50, 500);
 
-  QThread *grabbingThread = new QThread();
-
   usNetworkGrabberRF2D *qtGrabber = new usNetworkGrabberRF2D();
   qtGrabber->setIPAddress(ip.toStdString());
   qtGrabber->connectToServer();
@@ -71,10 +69,6 @@ int main(int argc, char **argv)
   qtGrabber->initAcquisition(header);
 
   qtGrabber->runAcquisition();
-
-  // Move the grabber object to another thread
-  qtGrabber->moveToThread(grabbingThread);
-  grabbingThread->start();
 
   writer.setSequenceFileName("./elastosequence.xml");
   writer.setImageFileName(std::string("./sequencepreElasto%04d.png"));

--- a/tutorial/ustk/elastography/tutorial-elastography-BMA-2D.cpp
+++ b/tutorial/ustk/elastography/tutorial-elastography-BMA-2D.cpp
@@ -26,8 +26,6 @@ int main(int argc, char **argv)
   elastography->setMotionEstimator(usElastography::BMA_TAYLOR);
   elastography->setROI(40, 3200, 50, 500);
 
-  QThread *grabbingThread = new QThread();
-
   usNetworkGrabberRF2D *qtGrabber = new usNetworkGrabberRF2D();
   qtGrabber->setIPAddress("127.0.0.1");
   qtGrabber->connectToServer();
@@ -62,10 +60,6 @@ int main(int argc, char **argv)
   qtGrabber->initAcquisition(header);
 
   qtGrabber->runAcquisition();
-
-  // Move the grabber object to another thread
-  qtGrabber->moveToThread(grabbingThread);
-  grabbingThread->start();
 
   std::cout << "waiting ultrasound initialisation..." << std::endl;
 

--- a/tutorial/ustk/tracking/tutorial-ultrasonix-servo-target-confidence.cpp
+++ b/tutorial/ustk/tracking/tutorial-ultrasonix-servo-target-confidence.cpp
@@ -465,8 +465,6 @@ int main(int argc, char **argv)
   usNetworkGrabberPreScan2D *qtGrabber = new usNetworkGrabberPreScan2D();
   qtGrabber->connectToServer();
 
-  QThread *grabbingThread = new QThread();
-
   // setting acquisition parameters
   usNetworkGrabber::usInitHeaderSent header;
   header.probeId = 15;    // 4DC7 id = 15
@@ -480,10 +478,6 @@ int main(int argc, char **argv)
   qtGrabber->setMotorPosition(37);
   qtGrabber->sendAcquisitionParameters();
   qtGrabber->runAcquisition();
-
-  // Move the grabber object to another thread
-  qtGrabber->moveToThread(grabbingThread);
-  grabbingThread->start();
 
   bool stop_capture_ = false;
 

--- a/tutorial/ustk/ultrasonix/tutorial-ultrasonix-qt-grabbing-RF-scan-conversion.cpp
+++ b/tutorial/ustk/ultrasonix/tutorial-ultrasonix-qt-grabbing-RF-scan-conversion.cpp
@@ -22,8 +22,6 @@ int main(int argc, char **argv)
   // QT application
   QApplication app(argc, argv);
 
-  QThread *grabbingThread = new QThread();
-
   usNetworkGrabberRF2D *qtGrabber = new usNetworkGrabberRF2D();
   qtGrabber->connectToServer();
 
@@ -78,10 +76,6 @@ int main(int argc, char **argv)
   qtGrabber->initAcquisition(header);
 
   qtGrabber->runAcquisition();
-
-  // Move the grabber object to another thread
-  qtGrabber->moveToThread(grabbingThread);
-  grabbingThread->start();
 
   std::cout << "waiting ultrasound initialisation..." << std::endl;
 

--- a/tutorial/ustk/ultrasonix/tutorial-ultrasonix-qt-grabbing-RF-scan-conversion.cpp
+++ b/tutorial/ustk/ultrasonix/tutorial-ultrasonix-qt-grabbing-RF-scan-conversion.cpp
@@ -81,43 +81,39 @@ int main(int argc, char **argv)
 
   // our local grabbing loop
   do {
-    if (qtGrabber->isFirstFrameAvailable()) {
-      grabbedFrame = qtGrabber->acquire();
+    grabbedFrame = qtGrabber->acquire();
 
-      std::cout << "MAIN THREAD received frame No : " << grabbedFrame->getFrameCount() << std::endl;
+    std::cout << "MAIN THREAD received frame No : " << grabbedFrame->getFrameCount() << std::endl;
 
-      double startTime = vpTime::measureTimeMs();
-      // convert RF to pre-scan to display something ...
-      converterRF.convert(*grabbedFrame, preScanImage);
+    double startTime = vpTime::measureTimeMs();
+    // convert RF to pre-scan to display something ...
+    converterRF.convert(*grabbedFrame, preScanImage);
 
-      double endRFConvertTime = vpTime::measureTimeMs();
-      std::cout << "RF conversion time (sec) = " << (endRFConvertTime - startTime) / 1000.0 << std::endl;
+    double endRFConvertTime = vpTime::measureTimeMs();
+    std::cout << "RF conversion time (sec) = " << (endRFConvertTime - startTime) / 1000.0 << std::endl;
 
-      scanConverter.convert(preScanImage, postscanImage);
+    scanConverter.convert(preScanImage, postscanImage);
 
-      double endScanConvertTime = vpTime::measureTimeMs();
-      std::cout << "scan-conversion time (sec) = " << (endScanConvertTime - endRFConvertTime) / 1000.0 << std::endl;
+    double endScanConvertTime = vpTime::measureTimeMs();
+    std::cout << "scan-conversion time (sec) = " << (endScanConvertTime - endRFConvertTime) / 1000.0 << std::endl;
 
-      // init display
-      if (!displayInit && postscanImage.getHeight() != 0 && postscanImage.getWidth() != 0) {
+    // init display
+    if (!displayInit && postscanImage.getHeight() != 0 && postscanImage.getWidth() != 0) {
 #if defined(VISP_HAVE_X11)
-        display = new vpDisplayX(postscanImage);
+      display = new vpDisplayX(postscanImage);
 #elif defined(VISP_HAVE_GDI)
-        display = new vpDisplayGDI(postscanImage);
+      display = new vpDisplayGDI(postscanImage);
 #endif
-        displayInit = true;
-      }
+      displayInit = true;
+    }
 
-      // processing display
-      if (displayInit) {
-        if (vpDisplay::getClick(postscanImage, false))
-          captureRunning = false;
-        vpDisplay::display(postscanImage);
-        vpDisplay::displayText(postscanImage, 20, 20, std::string("Click to exit..."), vpColor::red);
-        vpDisplay::flush(postscanImage);
-      }
-    } else {
-      vpTime::wait(10);
+    // processing display
+    if (displayInit) {
+      if (vpDisplay::getClick(postscanImage, false))
+        captureRunning = false;
+      vpDisplay::display(postscanImage);
+      vpDisplay::displayText(postscanImage, 20, 20, std::string("Click to exit..."), vpColor::red);
+      vpDisplay::flush(postscanImage);
     }
   } while (captureRunning);
 

--- a/tutorial/ustk/ultrasonix/tutorial-ultrasonix-qt-grabbing-RF.cpp
+++ b/tutorial/ustk/ultrasonix/tutorial-ultrasonix-qt-grabbing-RF.cpp
@@ -21,8 +21,6 @@ int main(int argc, char **argv)
   // QT application
   QApplication app(argc, argv);
 
-  QThread *grabbingThread = new QThread();
-
   usNetworkGrabberRF2D *qtGrabber = new usNetworkGrabberRF2D();
   qtGrabber->connectToServer();
 
@@ -68,10 +66,6 @@ int main(int argc, char **argv)
   // sending acquisition parameters
   qtGrabber->initAcquisition(header);
   qtGrabber->runAcquisition();
-
-  // Move the grabber object to another thread
-  qtGrabber->moveToThread(grabbingThread);
-  grabbingThread->start();
 
   std::cout << "waiting ultrasound initialisation..." << std::endl;
 

--- a/tutorial/ustk/ultrasonix/tutorial-ultrasonix-qt-grabbing-RF.cpp
+++ b/tutorial/ustk/ultrasonix/tutorial-ultrasonix-qt-grabbing-RF.cpp
@@ -71,37 +71,33 @@ int main(int argc, char **argv)
 
   // our local grabbing loop
   do {
-    if (qtGrabber->isFirstFrameAvailable()) {
-      grabbedFrame = qtGrabber->acquire();
+    grabbedFrame = qtGrabber->acquire();
 
-      std::cout << "MAIN THREAD received frame No : " << grabbedFrame->getFrameCount() << std::endl;
+    std::cout << "MAIN THREAD received frame No : " << grabbedFrame->getFrameCount() << std::endl;
 
-      // convert RF to pre-scan to display something ...
-      double t0 = vpTime::measureTimeMs();
-      converter.convert(*grabbedFrame, preScanImage);
-      double t1 = vpTime::measureTimeMs();
-      std::cout << "conversion time = " << t1 - t0 << std::endl;
+    // convert RF to pre-scan to display something ...
+    double t0 = vpTime::measureTimeMs();
+    converter.convert(*grabbedFrame, preScanImage);
+    double t1 = vpTime::measureTimeMs();
+    std::cout << "conversion time = " << t1 - t0 << std::endl;
 
-      // init display
-      if (!displayInit && preScanImage.getHeight() != 0 && preScanImage.getWidth() != 0) {
+    // init display
+    if (!displayInit && preScanImage.getHeight() != 0 && preScanImage.getWidth() != 0) {
 #if defined(VISP_HAVE_X11)
-        display = new vpDisplayX(preScanImage);
+      display = new vpDisplayX(preScanImage);
 #elif defined(VISP_HAVE_GDI)
-        display = new vpDisplayGDI(preScanImage);
+      display = new vpDisplayGDI(preScanImage);
 #endif
-        displayInit = true;
-      }
+      displayInit = true;
+    }
 
-      // processing display
-      if (displayInit) {
-        if (vpDisplay::getClick(preScanImage, false))
-          captureRunning = false;
-        vpDisplay::display(preScanImage);
-        vpDisplay::displayText(preScanImage, 20, 20, std::string("Click to exit..."), vpColor::red);
-        vpDisplay::flush(preScanImage);
-      }
-    } else {
-      vpTime::wait(10);
+    // processing display
+    if (displayInit) {
+      if (vpDisplay::getClick(preScanImage, false))
+        captureRunning = false;
+      vpDisplay::display(preScanImage);
+      vpDisplay::displayText(preScanImage, 20, 20, std::string("Click to exit..."), vpColor::red);
+      vpDisplay::flush(preScanImage);
     }
   } while (captureRunning);
 

--- a/tutorial/ustk/ultrasonix/tutorial-ultrasonix-qt-grabbing-RF3D.cpp
+++ b/tutorial/ustk/ultrasonix/tutorial-ultrasonix-qt-grabbing-RF3D.cpp
@@ -18,8 +18,6 @@ int main(int argc, char **argv)
   // QT application
   QApplication app(argc, argv);
 
-  QThread *grabbingThread = new QThread();
-
   usNetworkGrabberRF3D *qtGrabber = new usNetworkGrabberRF3D();
   qtGrabber->connectToServer();
   // qtGrabber->setVerbose(true);
@@ -47,10 +45,6 @@ int main(int argc, char **argv)
   qtGrabber->sendAcquisitionParameters();
 
   qtGrabber->runAcquisition();
-
-  // Move the grabber object to another thread
-  qtGrabber->moveToThread(grabbingThread);
-  grabbingThread->start();
 
   std::cout << "waiting ultrasound initialisation..." << std::endl;
 

--- a/tutorial/ustk/ultrasonix/tutorial-ultrasonix-qt-grabbing-RF3D.cpp
+++ b/tutorial/ustk/ultrasonix/tutorial-ultrasonix-qt-grabbing-RF3D.cpp
@@ -50,7 +50,6 @@ int main(int argc, char **argv)
 
   // our local grabbing loop
   do {
-    if (qtGrabber->isFirstFrameAvailable()) {
       grabbedVolume = qtGrabber->acquire();
 
       std::cout << "MAIN THREAD received volume No : " << grabbedVolume->getVolumeCount() << std::endl;
@@ -60,12 +59,11 @@ int main(int argc, char **argv)
 
       QString filename = QString("volume") + QString::number(grabbedVolume->getVolumeCount()) + QString(".mhd");
       usImageIo::write(preScanImage, filename.toStdString());
-    } else {
-      vpTime::wait(10);
-    }
   } while (captureRunning);
+    
+  qtGrabber->stopAcquisition();
 
-  return app.exec();
+  return 0;
 }
 
 #else

--- a/tutorial/ustk/ultrasonix/tutorial-ultrasonix-qt-grabbing-post-scan-bi-plan.cpp
+++ b/tutorial/ustk/ultrasonix/tutorial-ultrasonix-qt-grabbing-post-scan-bi-plan.cpp
@@ -18,8 +18,6 @@ int main(int argc, char **argv)
   // QT application
   QApplication app(argc, argv);
 
-  QThread *grabbingThread = new QThread();
-
   usNetworkGrabberPostScanBiPlan *qtGrabber = new usNetworkGrabberPostScanBiPlan();
   qtGrabber->connectToServer();
 
@@ -54,10 +52,6 @@ int main(int argc, char **argv)
 
   qtGrabber->sendAcquisitionParameters();
   qtGrabber->runAcquisition();
-
-  // Move the grabber object to another thread
-  qtGrabber->moveToThread(grabbingThread);
-  grabbingThread->start();
 
   std::cout << "waiting ultrasound initialisation..." << std::endl;
 

--- a/tutorial/ustk/ultrasonix/tutorial-ultrasonix-qt-grabbing-post-scan-bi-plan.cpp
+++ b/tutorial/ustk/ultrasonix/tutorial-ultrasonix-qt-grabbing-post-scan-bi-plan.cpp
@@ -57,39 +57,35 @@ int main(int argc, char **argv)
 
   // our local grabbing loop
   do {
-    if (qtGrabber->isFirstFrameAvailable()) {
+    grabbedFrame = qtGrabber->acquire();
 
-      grabbedFrame = qtGrabber->acquire();
+    std::cout << "MAIN THREAD received frame No : " << grabbedFrame[0]->getFrameCount() << " and "
+              << grabbedFrame[1]->getFrameCount() << std::endl;
 
-      std::cout << "MAIN THREAD received frame No : " << grabbedFrame[0]->getFrameCount() << " and "
-                << grabbedFrame[1]->getFrameCount() << std::endl;
-
-      // init display
-      if (!displayInit && grabbedFrame[0]->getHeight() != 0 && grabbedFrame[0]->getWidth() != 0) {
+    // init display
+    if (!displayInit && grabbedFrame[0]->getHeight() != 0 && grabbedFrame[0]->getWidth() != 0) {
 #if defined(VISP_HAVE_X11)
-        display1 = new vpDisplayX(*(grabbedFrame[0]));
-        display2 = new vpDisplayX(*(grabbedFrame[1]));
+      display1 = new vpDisplayX(*(grabbedFrame[0]));
+      display2 = new vpDisplayX(*(grabbedFrame[1]));
 #elif defined(VISP_HAVE_GDI)
-        display1 = new vpDisplayGDI(*(grabbedFrame[0]));
-        display2 = new vpDisplayGDI(*(grabbedFrame[1]));
+      display1 = new vpDisplayGDI(*(grabbedFrame[0]));
+      display2 = new vpDisplayGDI(*(grabbedFrame[1]));
 #endif
-        displayInit = true;
-      }
-
-      // processing display
-      if (displayInit) {
-        if (vpDisplay::getClick(*grabbedFrame[0], false) || vpDisplay::getClick(*grabbedFrame[1], false))
-          captureRunning = false;
-        vpDisplay::display(*(grabbedFrame[0]));
-        vpDisplay::display(*(grabbedFrame[1]));
-        vpDisplay::displayText(*grabbedFrame[0], 20, 20, std::string("Click to exit..."), vpColor::red);
-        vpDisplay::displayText(*grabbedFrame[1], 20, 20, std::string("Click to exit..."), vpColor::red);
-        vpDisplay::flush(*(grabbedFrame[0]));
-        vpDisplay::flush(*(grabbedFrame[1]));
-      }
-    } else {
-      vpTime::wait(10);
+      displayInit = true;
     }
+
+    // processing display
+    if (displayInit) {
+      if (vpDisplay::getClick(*grabbedFrame[0], false) || vpDisplay::getClick(*grabbedFrame[1], false))
+        captureRunning = false;
+      vpDisplay::display(*(grabbedFrame[0]));
+      vpDisplay::display(*(grabbedFrame[1]));
+      vpDisplay::displayText(*grabbedFrame[0], 20, 20, std::string("Click to exit..."), vpColor::red);
+      vpDisplay::displayText(*grabbedFrame[1], 20, 20, std::string("Click to exit..."), vpColor::red);
+      vpDisplay::flush(*(grabbedFrame[0]));
+      vpDisplay::flush(*(grabbedFrame[1]));
+    }
+
   } while (captureRunning);
 
   qtGrabber->stopAcquisition();

--- a/tutorial/ustk/ultrasonix/tutorial-ultrasonix-qt-grabbing-post-scan.cpp
+++ b/tutorial/ustk/ultrasonix/tutorial-ultrasonix-qt-grabbing-post-scan.cpp
@@ -19,8 +19,6 @@ int main(int argc, char **argv)
   // QT application
   QApplication app(argc, argv);
 
-  QThread *grabbingThread = new QThread();
-
   usNetworkGrabberPostScan2D *qtGrabber = new usNetworkGrabberPostScan2D();
   qtGrabber->connectToServer();
 
@@ -77,10 +75,6 @@ int main(int argc, char **argv)
   qtGrabber->sendAcquisitionParameters();
   std::cout << "end update" << std::endl;
   qtGrabber->runAcquisition();
-
-  // Move the grabber object to another thread
-  qtGrabber->moveToThread(grabbingThread);
-  grabbingThread->start();
 
   std::cout << "waiting ultrasound initialisation..." << std::endl;
 

--- a/tutorial/ustk/ultrasonix/tutorial-ultrasonix-qt-grabbing-post-scan.cpp
+++ b/tutorial/ustk/ultrasonix/tutorial-ultrasonix-qt-grabbing-post-scan.cpp
@@ -80,34 +80,30 @@ int main(int argc, char **argv)
 
   // our local grabbing loop
   do {
-    if (qtGrabber->isFirstFrameAvailable()) {
-      grabbedFrame = qtGrabber->acquire();
+    grabbedFrame = qtGrabber->acquire();
 
-      std::cout << "MAIN THREAD received frame No : " << grabbedFrame->getFrameCount() << std::endl;
+    std::cout << "MAIN THREAD received frame No : " << grabbedFrame->getFrameCount() << std::endl;
 
-      std::cout << *grabbedFrame << std::endl;
+    std::cout << *grabbedFrame << std::endl;
 
-      // init display
-      if (!displayInit && grabbedFrame->getHeight() != 0 && grabbedFrame->getWidth() != 0) {
+    // init display
+    if (!displayInit && grabbedFrame->getHeight() != 0 && grabbedFrame->getWidth() != 0) {
 #if defined(VISP_HAVE_X11)
-        display = new vpDisplayX(*grabbedFrame);
+      display = new vpDisplayX(*grabbedFrame);
 #elif defined(VISP_HAVE_GDI)
-        display = new vpDisplayGDI(*grabbedFrame);
+      display = new vpDisplayGDI(*grabbedFrame);
 #endif
-        qtGrabber->useVpDisplay(display);
-        displayInit = true;
-      }
+      qtGrabber->useVpDisplay(display);
+      displayInit = true;
+    }
 
-      // processing display
-      if (displayInit) {
-        if (vpDisplay::getClick(*grabbedFrame, false))
-          captureRunning = false;
-        vpDisplay::display(*grabbedFrame);
-        vpDisplay::displayText(*grabbedFrame, 20, 20, std::string("Click to exit..."), vpColor::red);
-        vpDisplay::flush(*grabbedFrame);
-      }
-    } else {
-      vpTime::wait(10);
+    // processing display
+    if (displayInit) {
+      if (vpDisplay::getClick(*grabbedFrame, false))
+        captureRunning = false;
+      vpDisplay::display(*grabbedFrame);
+      vpDisplay::displayText(*grabbedFrame, 20, 20, std::string("Click to exit..."), vpColor::red);
+      vpDisplay::flush(*grabbedFrame);
     }
   } while (captureRunning);
 

--- a/tutorial/ustk/ultrasonix/tutorial-ultrasonix-qt-grabbing-post-scan3D.cpp
+++ b/tutorial/ustk/ultrasonix/tutorial-ultrasonix-qt-grabbing-post-scan3D.cpp
@@ -21,8 +21,6 @@ int main(int argc, char **argv)
   // QT application
   QApplication app(argc, argv);
 
-  QThread *grabbingThread = new QThread();
-
   usNetworkGrabberPostScan2D *qtGrabber = new usNetworkGrabberPostScan2D();
   qtGrabber->connectToServer();
 
@@ -70,10 +68,6 @@ int main(int argc, char **argv)
   qtGrabber->sendAcquisitionParameters();
   std::cout << "end update" << std::endl;
   qtGrabber->runAcquisition();
-
-  // Move the grabber object to another thread
-  qtGrabber->moveToThread(grabbingThread);
-  grabbingThread->start();
 
   std::cout << "waiting ultrasound initialisation..." << std::endl;
 

--- a/tutorial/ustk/ultrasonix/tutorial-ultrasonix-qt-grabbing-post-scan3D.cpp
+++ b/tutorial/ustk/ultrasonix/tutorial-ultrasonix-qt-grabbing-post-scan3D.cpp
@@ -73,43 +73,41 @@ int main(int argc, char **argv)
 
   // our local grabbing loop
   do {
-    if (qtGrabber->isFirstFrameAvailable()) {
-      grabbedFrame = qtGrabber->acquire();
+    grabbedFrame = qtGrabber->acquire();
 
-      std::cout << "MAIN THREAD received frame No : " << grabbedFrame->getFrameCount() << std::endl;
+    std::cout << "MAIN THREAD received frame No : " << grabbedFrame->getFrameCount() << std::endl;
 
-      std::cout << *grabbedFrame << std::endl;
+    std::cout << *grabbedFrame << std::endl;
 
-      char buffer[400];
-      sprintf(buffer, "frame%d.png", grabbedFrame->getFrameCount());
+    char buffer[400];
+    sprintf(buffer, "frame%d.png", grabbedFrame->getFrameCount());
 
-      // std::string fileName = "frame" + grabbedFrame->getFrameCount() + ".png";
-      vpImageIo::write(*grabbedFrame, buffer);
-      // init display
-      if (!displayInit && grabbedFrame->getHeight() != 0 && grabbedFrame->getWidth() != 0) {
+    // std::string fileName = "frame" + grabbedFrame->getFrameCount() + ".png";
+    vpImageIo::write(*grabbedFrame, buffer);
+    // init display
+    if (!displayInit && grabbedFrame->getHeight() != 0 && grabbedFrame->getWidth() != 0) {
 #if defined(VISP_HAVE_X11)
-        display = new vpDisplayX(*grabbedFrame);
+      display = new vpDisplayX(*grabbedFrame);
 #elif defined(VISP_HAVE_GDI)
-        display = new vpDisplayGDI(*grabbedFrame);
+      display = new vpDisplayGDI(*grabbedFrame);
 #endif
-        displayInit = true;
-      }
+      displayInit = true;
+    }
 
-      // processing display
-      if (displayInit) {
-        vpDisplay::display(*grabbedFrame);
-        vpDisplay::flush(*grabbedFrame);
-      }
-    } else {
-      vpTime::wait(10);
+    // processing display
+    if (displayInit) {
+      vpDisplay::display(*grabbedFrame);
+      vpDisplay::flush(*grabbedFrame);
     }
   } while (captureRunning);
+  
+  qtGrabber->stopAcquisition();
 
   if (displayInit) {
     delete display;
   }
 
-  return app.exec();
+  return 0;
 }
 
 #else

--- a/tutorial/ustk/ultrasonix/tutorial-ultrasonix-qt-grabbing-pre-scan-confidence-control.cpp
+++ b/tutorial/ustk/ultrasonix/tutorial-ultrasonix-qt-grabbing-pre-scan-confidence-control.cpp
@@ -278,8 +278,6 @@ int main(int argc, char **argv)
   // QT application
   QApplication app(argc, argv);
 
-  QThread *grabbingThread = new QThread();
-
   usNetworkGrabberPreScan2D *qtGrabber = new usNetworkGrabberPreScan2D();
   qtGrabber->connectToServer();
 
@@ -325,10 +323,6 @@ int main(int argc, char **argv)
   qtGrabber->sendAcquisitionParameters();
 
   qtGrabber->runAcquisition();
-
-  // Move the grabber object to another thread, and run it
-  qtGrabber->moveToThread(grabbingThread);
-  grabbingThread->start();
 
   // start robot control thread
   vpThread thread_control((vpThread::Fn)controlFunction);

--- a/tutorial/ustk/ultrasonix/tutorial-ultrasonix-qt-grabbing-pre-scan-confidence.cpp
+++ b/tutorial/ustk/ultrasonix/tutorial-ultrasonix-qt-grabbing-pre-scan-confidence.cpp
@@ -21,8 +21,6 @@ int main(int argc, char **argv)
   // QT application
   QApplication app(argc, argv);
 
-  QThread *grabbingThread = new QThread();
-
   usNetworkGrabberPreScan2D *qtGrabber = new usNetworkGrabberPreScan2D();
   qtGrabber->connectToServer();
 
@@ -67,10 +65,6 @@ int main(int argc, char **argv)
   qtGrabber->initAcquisition(header);
 
   qtGrabber->runAcquisition();
-
-  // Move the grabber object to another thread, and run it
-  qtGrabber->moveToThread(grabbingThread);
-  grabbingThread->start();
 
   // our local grabbing loop
   do {

--- a/tutorial/ustk/ultrasonix/tutorial-ultrasonix-qt-grabbing-pre-scan-confidence.cpp
+++ b/tutorial/ustk/ultrasonix/tutorial-ultrasonix-qt-grabbing-pre-scan-confidence.cpp
@@ -68,43 +68,39 @@ int main(int argc, char **argv)
 
   // our local grabbing loop
   do {
-    if (qtGrabber->isFirstFrameAvailable()) {
-      grabbedFrame = qtGrabber->acquire();
-      confidenceProcessor.run(confidence, *grabbedFrame);
-      // local copy for vpDisplay
-      // localFrame = *grabbedFrame;
+    grabbedFrame = qtGrabber->acquire();
+    confidenceProcessor.run(confidence, *grabbedFrame);
+    // local copy for vpDisplay
+    // localFrame = *grabbedFrame;
 
-      std::cout << "MAIN THREAD received frame No : " << grabbedFrame->getFrameCount() << std::endl;
+    std::cout << "MAIN THREAD received frame No : " << grabbedFrame->getFrameCount() << std::endl;
 
-      std::cout << *grabbedFrame << std::endl;
+    std::cout << *grabbedFrame << std::endl;
 
-      // init display
-      if (!displayInit && grabbedFrame->getHeight() != 0 && grabbedFrame->getWidth() != 0) {
+    // init display
+    if (!displayInit && grabbedFrame->getHeight() != 0 && grabbedFrame->getWidth() != 0) {
 #if defined(VISP_HAVE_X11)
-        display = new vpDisplayX(*grabbedFrame);
-        displayConf = new vpDisplayX(confidence);
+      display = new vpDisplayX(*grabbedFrame);
+      displayConf = new vpDisplayX(confidence);
 #elif defined(VISP_HAVE_GDI)
-        display = new vpDisplayGDI(*grabbedFrame);
-        displayConf = new vpDisplayGDI(confidence);
+      display = new vpDisplayGDI(*grabbedFrame);
+      displayConf = new vpDisplayGDI(confidence);
 #endif
-        qtGrabber->useVpDisplay(display);
-        displayInit = true;
-      }
+      qtGrabber->useVpDisplay(display);
+      displayInit = true;
+    }
 
-      // processing display
-      if (displayInit) {
-        if (vpDisplay::getClick(*grabbedFrame, false))
-          captureRunning = false;
-        vpDisplay::display(*grabbedFrame);
-        vpDisplay::displayText(*grabbedFrame, 20, 20, std::string("Click to exit..."), vpColor::red);
-        vpDisplay::flush(*grabbedFrame);
-        vpDisplay::display(confidence);
-        vpDisplay::displayText(confidence, 20, 20, std::string("Click to exit..."), vpColor::red);
-        vpDisplay::flush(confidence);
-        // vpTime::wait(10); // wait to simulate a local process running on last frame frabbed
-      }
-    } else {
-      vpTime::wait(10);
+    // processing display
+    if (displayInit) {
+      if (vpDisplay::getClick(*grabbedFrame, false))
+        captureRunning = false;
+      vpDisplay::display(*grabbedFrame);
+      vpDisplay::displayText(*grabbedFrame, 20, 20, std::string("Click to exit..."), vpColor::red);
+      vpDisplay::flush(*grabbedFrame);
+      vpDisplay::display(confidence);
+      vpDisplay::displayText(confidence, 20, 20, std::string("Click to exit..."), vpColor::red);
+      vpDisplay::flush(confidence);
+      // vpTime::wait(10); // wait to simulate a local process running on last frame frabbed
     }
   } while (captureRunning);
 

--- a/tutorial/ustk/ultrasonix/tutorial-ultrasonix-qt-grabbing-pre-scan.cpp
+++ b/tutorial/ustk/ultrasonix/tutorial-ultrasonix-qt-grabbing-pre-scan.cpp
@@ -69,32 +69,28 @@ int main(int argc, char **argv)
 
   // our grabbing loop
   do {
-    if (qtGrabber->isFirstFrameAvailable()) {
-      grabbedFrame = qtGrabber->acquire();
+    grabbedFrame = qtGrabber->acquire();
 
-      std::cout << "MAIN THREAD received frame No : " << grabbedFrame->getFrameCount() << std::endl;
+    std::cout << "MAIN THREAD received frame No : " << grabbedFrame->getFrameCount() << std::endl;
 
-      // init display
-      if (!displayInit && grabbedFrame->getHeight() != 0 && grabbedFrame->getWidth() != 0) {
+    // init display
+    if (!displayInit && grabbedFrame->getHeight() != 0 && grabbedFrame->getWidth() != 0) {
 #if defined(VISP_HAVE_X11)
-        display = new vpDisplayX(*grabbedFrame);
+      display = new vpDisplayX(*grabbedFrame);
 #elif defined(VISP_HAVE_GDI)
-        display = new vpDisplayGDI(*grabbedFrame);
+      display = new vpDisplayGDI(*grabbedFrame);
 #endif
-        qtGrabber->useVpDisplay(display);
-        displayInit = true;
-      }
+      qtGrabber->useVpDisplay(display);
+      displayInit = true;
+    }
 
-      // processing display
-      if (displayInit) {
-        if (vpDisplay::getClick(*grabbedFrame, false))
-          captureRunning = false;
-        vpDisplay::display(*grabbedFrame);
-        vpDisplay::displayText(*grabbedFrame, 20, 20, std::string("Click to exit..."), vpColor::red);
-        vpDisplay::flush(*grabbedFrame);
-      }
-    } else {
-      vpTime::wait(10);
+    // processing display
+    if (displayInit) {
+      if (vpDisplay::getClick(*grabbedFrame, false))
+        captureRunning = false;
+      vpDisplay::display(*grabbedFrame);
+      vpDisplay::displayText(*grabbedFrame, 20, 20, std::string("Click to exit..."), vpColor::red);
+      vpDisplay::flush(*grabbedFrame);
     }
   } while (captureRunning);
 

--- a/tutorial/ustk/ultrasonix/tutorial-ultrasonix-qt-grabbing-pre-scan.cpp
+++ b/tutorial/ustk/ultrasonix/tutorial-ultrasonix-qt-grabbing-pre-scan.cpp
@@ -19,8 +19,6 @@ int main(int argc, char **argv)
   // QT application
   QApplication app(argc, argv);
 
-  QThread *grabbingThread = new QThread();
-
   usNetworkGrabberPreScan2D *qtGrabber = new usNetworkGrabberPreScan2D();
   qtGrabber->connectToServer();
 
@@ -68,10 +66,6 @@ int main(int argc, char **argv)
 
   // Send the command to run the acquisition
   qtGrabber->runAcquisition();
-
-  // Move the grabber object to another thread, and run it
-  qtGrabber->moveToThread(grabbingThread);
-  grabbingThread->start();
 
   // our grabbing loop
   do {

--- a/tutorial/ustk/ultrasonix/tutorial-ultrasonix-qt-grabbing-pre-scan3D.cpp
+++ b/tutorial/ustk/ultrasonix/tutorial-ultrasonix-qt-grabbing-pre-scan3D.cpp
@@ -21,8 +21,6 @@ int main(int argc, char **argv)
   // QT application
   QApplication app(argc, argv);
 
-  QThread *grabbingThread = new QThread();
-
   usNetworkGrabberPreScan3D *qtGrabber = new usNetworkGrabberPreScan3D();
   qtGrabber->connectToServer();
 
@@ -53,10 +51,6 @@ int main(int argc, char **argv)
 
   // Send the command to run the acquisition
   qtGrabber->runAcquisition();
-
-  // Move the grabber object to another thread, and run it
-  qtGrabber->moveToThread(grabbingThread);
-  grabbingThread->start();
 
   // our grabbing loop
   do {

--- a/tutorial/ustk/ultrasonix/tutorial-ultrasonix-qt-grabbing-pre-scan3D.cpp
+++ b/tutorial/ustk/ultrasonix/tutorial-ultrasonix-qt-grabbing-pre-scan3D.cpp
@@ -54,21 +54,20 @@ int main(int argc, char **argv)
 
   // our grabbing loop
   do {
-    if (qtGrabber->isFirstFrameAvailable()) {
-      grabbedFrame = qtGrabber->acquire();
+    grabbedFrame = qtGrabber->acquire();
 
-      std::cout << "MAIN THREAD received volume No : " << grabbedFrame->getVolumeCount() << std::endl;
+    std::cout << "MAIN THREAD received volume No : " << grabbedFrame->getVolumeCount() << std::endl;
 
-      char buffer[FILENAME_MAX];
-      sprintf(buffer, "volumePreScan%d.mhd", grabbedFrame->getVolumeCount());
+    char buffer[FILENAME_MAX];
+    sprintf(buffer, "volumePreScan%d.mhd", grabbedFrame->getVolumeCount());
 
-      usImageIo::write(*grabbedFrame, buffer);
-    } else {
-      vpTime::wait(10);
-    }
+    usImageIo::write(*grabbedFrame, buffer);
+
   } while (captureRunning);
+  
+  qtGrabber->stopAcquisition();
 
-  return app.exec();
+  return 0;
 }
 
 #else

--- a/tutorial/ustk/virtualServerClients/tutorial-ustk-virtual-server-RF2D.cpp
+++ b/tutorial/ustk/virtualServerClients/tutorial-ustk-virtual-server-RF2D.cpp
@@ -23,8 +23,6 @@ int main(int argc, char **argv)
   // QT application
   QApplication app(argc, argv);
 
-  QThread *grabbingThread = new QThread();
-
   usNetworkGrabberRF2D *qtGrabber = new usNetworkGrabberRF2D();
   qtGrabber->setIPAddress("127.0.0.1"); // local loop, server must be running on same computer
   qtGrabber->connectToServer();
@@ -63,10 +61,6 @@ int main(int argc, char **argv)
   qtGrabber->initAcquisition(header);
   std::cout << "init success" << std::endl;
   qtGrabber->runAcquisition();
-
-  // Move the grabber object to another thread
-  qtGrabber->moveToThread(grabbingThread);
-  grabbingThread->start();
 
   std::cout << "waiting ultrasound initialisation..." << std::endl;
 

--- a/tutorial/ustk/virtualServerClients/tutorial-ustk-virtual-server-RF3D.cpp
+++ b/tutorial/ustk/virtualServerClients/tutorial-ustk-virtual-server-RF3D.cpp
@@ -27,8 +27,6 @@ int main(int argc, char **argv)
     outputPath = app.arguments().at(app.arguments().indexOf(QString("--output")) + 1);
   }
 
-  QThread *grabbingThread = new QThread();
-
   usNetworkGrabberRF3D *qtGrabber = new usNetworkGrabberRF3D();
   qtGrabber->setIPAddress("127.0.0.1"); // local loop, server must be running on same computer
   qtGrabber->connectToServer();
@@ -57,10 +55,6 @@ int main(int argc, char **argv)
   qtGrabber->initAcquisition(header);
   std::cout << "init success" << std::endl;
   qtGrabber->runAcquisition();
-
-  // Move the grabber object to another thread
-  qtGrabber->moveToThread(grabbingThread);
-  grabbingThread->start();
 
   std::cout << "waiting ultrasound initialisation..." << std::endl;
 

--- a/tutorial/ustk/virtualServerClients/tutorial-ustk-virtual-server-postScan2D.cpp
+++ b/tutorial/ustk/virtualServerClients/tutorial-ustk-virtual-server-postScan2D.cpp
@@ -22,8 +22,6 @@ int main(int argc, char **argv)
   // QT application
   QApplication app(argc, argv);
 
-  QThread *grabbingThread = new QThread();
-
   usNetworkGrabberPostScan2D *qtGrabber = new usNetworkGrabberPostScan2D();
   qtGrabber->setIPAddress("127.0.0.1"); // local loop, server must be running on same computer
   qtGrabber->connectToServer();
@@ -58,10 +56,6 @@ int main(int argc, char **argv)
   qtGrabber->initAcquisition(header);
   std::cout << "init success" << std::endl;
   qtGrabber->runAcquisition();
-
-  // Move the grabber object to another thread
-  qtGrabber->moveToThread(grabbingThread);
-  grabbingThread->start();
 
   std::cout << "waiting ultrasound initialisation..." << std::endl;
 

--- a/tutorial/ustk/virtualServerClients/tutorial-ustk-virtual-server-preScan2D.cpp
+++ b/tutorial/ustk/virtualServerClients/tutorial-ustk-virtual-server-preScan2D.cpp
@@ -22,8 +22,6 @@ int main(int argc, char **argv)
   // QT application
   QApplication app(argc, argv);
 
-  QThread *grabbingThread = new QThread();
-
   usNetworkGrabberPreScan2D *qtGrabber = new usNetworkGrabberPreScan2D();
   qtGrabber->setIPAddress("127.0.0.1"); // local loop, server must be running on same computer
   qtGrabber->connectToServer();
@@ -58,10 +56,6 @@ int main(int argc, char **argv)
   qtGrabber->initAcquisition(header);
   std::cout << "init success" << std::endl;
   qtGrabber->runAcquisition();
-
-  // Move the grabber object to another thread
-  qtGrabber->moveToThread(grabbingThread);
-  grabbingThread->start();
 
   std::cout << "waiting ultrasound initialisation..." << std::endl;
 

--- a/tutorial/ustk/virtualServerClients/tutorial-ustk-virtual-server-preScan3D.cpp
+++ b/tutorial/ustk/virtualServerClients/tutorial-ustk-virtual-server-preScan3D.cpp
@@ -22,8 +22,6 @@ int main(int argc, char **argv)
   // QT application
   QApplication app(argc, argv);
 
-  QThread *grabbingThread = new QThread();
-
   usNetworkGrabberPreScan3D *qtGrabber = new usNetworkGrabberPreScan3D();
   qtGrabber->setIPAddress("127.0.0.1"); // local loop, server must be running on same computer
   qtGrabber->connectToServer();
@@ -48,10 +46,6 @@ int main(int argc, char **argv)
   qtGrabber->initAcquisition(header);
   std::cout << "init success" << std::endl;
   qtGrabber->runAcquisition();
-
-  // Move the grabber object to another thread
-  qtGrabber->moveToThread(grabbingThread);
-  grabbingThread->start();
 
   std::cout << "waiting ultrasound initialisation..." << std::endl;
 


### PR DESCRIPTION
Fix several issues in ultrasound grabbers and prescan to postscan converter:
 - Fix several cases of width/height inversion in 3D images
 - Simplify the use of US grabbers by including the polling thread creation into the class
 - Simplify redundant code and non necessary variables in grabbers
 - Fix a bug in grabbers when there is a delay between the call to runAcquisition() and the first call to acquire()
 - Fix an issue of bad frame inversion during 3D image acquisition with the wobbling probe
 - Add several computation methods to the 3D prescan to postscan converter