### PR TITLE
Add NDI needle model

### DIFF
--- a/modules/ustk_needle_modeling/include/visp3/ustk_needle_modeling/usNeedleInsertionModelKinematic.h
+++ b/modules/ustk_needle_modeling/include/visp3/ustk_needle_modeling/usNeedleInsertionModelKinematic.h
@@ -72,6 +72,7 @@ public:
   bool moveBase(double vz, double wz, double time);
   bool moveBase(double controlCurvature, double vz, double wz, double time);
 
+  using usNeedleInsertionModelInterface::setBasePose;
   bool setBasePose(const vpPoseVector &pose);
   vpPoseVector getBasePose() const;
 };

--- a/modules/ustk_needle_modeling/include/visp3/ustk_needle_modeling/usNeedleInsertionModelRayleighRitzSpline.h
+++ b/modules/ustk_needle_modeling/include/visp3/ustk_needle_modeling/usNeedleInsertionModelRayleighRitzSpline.h
@@ -177,6 +177,7 @@ public:
 
   //! Control of the needle
 
+  using usNeedleInsertionModelInterface::setBasePose;
   bool setBasePose(const vpPoseVector &p);
   vpPoseVector getBasePose() const;
 

--- a/modules/ustk_needle_modeling/include/visp3/ustk_needle_modeling/usNeedleInsertionModelRayleighRitzSpline.h
+++ b/modules/ustk_needle_modeling/include/visp3/ustk_needle_modeling/usNeedleInsertionModelRayleighRitzSpline.h
@@ -63,7 +63,8 @@ public:
     SteelSoftTissue,
     SRL_ActuatedFBG,
     SRL_BiopsySimple,
-    SRL_BiopsyNID
+    SRL_BiopsyNID,
+    NDI_Pink_Stylet
   };
   enum class PathUpdateType : int { NoUpdate, WithTipPosition, WithTipDirection, WithTipMix };
   enum class NeedleTipType : int { SymmetricTip, BeveledTip, PrebentTip, ActuatedTip };

--- a/modules/ustk_needle_modeling/include/visp3/ustk_needle_modeling/usNeedleInsertionModelVirtualSprings.h
+++ b/modules/ustk_needle_modeling/include/visp3/ustk_needle_modeling/usNeedleInsertionModelVirtualSprings.h
@@ -58,7 +58,8 @@ public:
     MisraRSRO10_PlastisolA,
     RoesthuisAM12,
     SteelSoftTissue,
-    SRL_BiopsyNID
+    SRL_BiopsyNID,
+    NDI_Pink_Stylet
   };
 
 protected:

--- a/modules/ustk_needle_modeling/include/visp3/ustk_needle_modeling/usNeedleInsertionModelVirtualSprings.h
+++ b/modules/ustk_needle_modeling/include/visp3/ustk_needle_modeling/usNeedleInsertionModelVirtualSprings.h
@@ -203,6 +203,7 @@ public:
 
   //! Control of the needle
 
+  using usNeedleInsertionModelInterface::setBasePose;
   bool setBasePose(const vpPoseVector &p);
   vpPoseVector getBasePose() const;
 

--- a/modules/ustk_needle_modeling/include/visp3/ustk_needle_modeling/usNeedleModelSpline.h
+++ b/modules/ustk_needle_modeling/include/visp3/ustk_needle_modeling/usNeedleModelSpline.h
@@ -53,7 +53,8 @@ public:
     SteelSoftTissue,
     SRL_ActuatedFBG,
     SRL_BiopsySimple,
-    SRL_BiopsyNID
+    SRL_BiopsyNID,
+    NDI_Pink_Stylet
   };
 
 protected:

--- a/modules/ustk_needle_modeling/src/usInsertionModel/usNeedleInsertionModelRayleighRitzSpline.cpp
+++ b/modules/ustk_needle_modeling/src/usInsertionModel/usNeedleInsertionModelRayleighRitzSpline.cpp
@@ -219,6 +219,17 @@ void usNeedleInsertionModelRayleighRitzSpline::loadPreset(const ModelPreset pres
       this->setStiffnessPerUnitLength(i, 20000);
     break;
   }
+  case ModelPreset::NDI_Pink_Stylet: {
+    m_needle.loadPreset(usNeedleModelSpline::NeedlePreset::NDI_Pink_Stylet);
+    this->setNeedleTipType(NeedleTipType::BeveledTip);
+    usNeedleTipBeveled *t = dynamic_cast<usNeedleTipBeveled *>(m_needleTip);
+    double d = m_needle.getOuterDiameter();
+    t->setDiameter(d);
+    t->setLength(d / tan(M_PI / 180 * 26));
+    for (unsigned int i = 0; i < m_stiffnessPerUnitLength.size(); i++)
+      this->setStiffnessPerUnitLength(i, 20000);
+    break;
+  }
   }
 }
 

--- a/modules/ustk_needle_modeling/src/usInsertionModel/usNeedleInsertionModelVirtualSprings.cpp
+++ b/modules/ustk_needle_modeling/src/usInsertionModel/usNeedleInsertionModelVirtualSprings.cpp
@@ -219,6 +219,16 @@ void usNeedleInsertionModelVirtualSprings::loadPreset(const ModelPreset preset)
     this->setBevelAngle(M_PI / 180 * 30);
     break;
   }
+  case ModelPreset::NDI_Pink_Stylet: {
+    m_needle.loadPreset(usNeedleModelSpline::NeedlePreset::NDI_Pink_Stylet);
+    this->setInterSpringDistance(0.005);
+    this->setInterTipSpringDistance(0.0005);
+    this->setNbMinTipSprings(10);
+    this->setNbMaxTipSprings(12);
+    this->setStiffnessPerUnitLength(20000);
+    this->setBevelAngle(M_PI / 180 * 26);
+    break;
+  }
   }
 }
 

--- a/modules/ustk_needle_modeling/src/usNeedleModel/usNeedleModelSpline.cpp
+++ b/modules/ustk_needle_modeling/src/usNeedleModel/usNeedleModelSpline.cpp
@@ -143,6 +143,13 @@ void usNeedleModelSpline::loadPreset(const NeedlePreset preset)
     this->setNeedleYoungModulus(200e9);
     break;
   }
+  case NeedlePreset::NDI_Pink_Stylet: {
+    this->setFullLength(0.148);
+    this->setOuterDiameter(0.00105);
+    this->setInsideDiameter(0.000838);
+    this->setNeedleYoungModulus(200e9);
+    break;
+  }
   }
 }
 


### PR DESCRIPTION
- Add a preset to the needle model classes to represent the NDI needle with electromagnetic tip tracker (18G needle, with pink base).
- Fix a bug that made the methods setBasePose() of usNeedleInsertionModelInterface unusable.